### PR TITLE
Support for sequence to profile alignments

### DIFF
--- a/benches/prefix_scan.rs
+++ b/benches/prefix_scan.rs
@@ -17,8 +17,9 @@ fn bench_opt_prefix_scan(b: &mut Bencher) {
         let vec = simd_load(vec.0.as_ptr() as *const Simd);
 
         b.iter(|| {
-            let consts = get_prefix_scan_consts(-1);
-            simd_prefix_scan_i16(black_box(vec), consts)
+            let gap = simd_set1_i16(-1);
+            let (_, consts) = get_prefix_scan_consts(gap);
+            simd_prefix_scan_i16(black_box(vec), gap, consts)
         });
     }
     unsafe { inner(b); }
@@ -32,8 +33,9 @@ fn bench_naive_prefix_scan(b: &mut Bencher) {
         let vec = simd_load(vec.0.as_ptr() as *const Simd);
 
         b.iter(|| {
-            let consts = get_prefix_scan_consts(-1);
-            simd_naive_prefix_scan_i16(black_box(vec), consts)
+            let gap = simd_set1_i16(-1);
+            let (_, consts) = get_prefix_scan_consts(gap);
+            simd_naive_prefix_scan_i16(black_box(vec), gap, consts)
         });
     }
     unsafe { inner(b); }

--- a/benches/rand_scan.rs
+++ b/benches/rand_scan.rs
@@ -36,7 +36,7 @@ fn bench_parasailors_aa_core<const K: usize>(b: &mut Bencher, len: usize) {
     let r = black_box(rand_str(len, &AMINO_ACIDS, &mut rng));
     let q = black_box(rand_mutate(&r, K, &AMINO_ACIDS, &mut rng));
     let matrix = Matrix::new(MatrixType::Blosum62);
-    let profile = Profile::new(&q, &matrix);
+    let profile = parasailors::Profile::new(&q, &matrix);
 
     b.iter(|| {
         global_alignment_score(&profile, &r, 11, 1)

--- a/examples/nanopore_accuracy.rs
+++ b/examples/nanopore_accuracy.rs
@@ -23,7 +23,7 @@ fn test(file_name: &str, min_size: usize, max_size: usize, verbose: bool) -> (us
 
         // parasail
         let matrix = Matrix::new(MatrixType::IdentityWithPenalty);
-        let profile = Profile::new(q.as_bytes(), &matrix);
+        let profile = parasailors::Profile::new(q.as_bytes(), &matrix);
         let parasail_score = global_alignment_score(&profile, r.as_bytes(), 2, 1);
 
         let r_padded = PaddedBytes::from_bytes::<NucMatrix>(r.as_bytes(), 2048);

--- a/examples/nanopore_bench.rs
+++ b/examples/nanopore_bench.rs
@@ -61,8 +61,8 @@ fn bench_parasailors_nuc_core(file: bool, _trace: bool, _max_size: usize) -> (i3
     let matrix = Matrix::new(MatrixType::IdentityWithPenalty);
     let data = file_data
         .iter()
-        .map(|(q, r)| (Profile::new(q, &matrix), r.to_owned()))
-        .collect::<Vec<(Profile, Vec<u8>)>>();
+        .map(|(q, r)| (parasailors::Profile::new(q, &matrix), r.to_owned()))
+        .collect::<Vec<(parasailors::Profile, Vec<u8>)>>();
 
     let start = Instant::now();
     let mut temp = 0i32;

--- a/examples/uc_bench.rs
+++ b/examples/uc_bench.rs
@@ -67,8 +67,8 @@ fn bench_parasailors_aa_core(idx: usize, _trace: bool, _min_size: usize, _max_si
     let matrix = Matrix::new(MatrixType::Blosum62);
     let data = file_data
         .iter()
-        .map(|(q, r)| (Profile::new(q, &matrix), r.to_owned()))
-        .collect::<Vec<(Profile, Vec<u8>)>>();
+        .map(|(q, r)| (parasailors::Profile::new(q, &matrix), r.to_owned()))
+        .collect::<Vec<(parasailors::Profile, Vec<u8>)>>();
 
     let start = Instant::now();
     let mut temp = 0i32;

--- a/src/avx2.rs
+++ b/src/avx2.rs
@@ -322,43 +322,6 @@ pub unsafe fn simd_prefix_scan_i16(R_max: Simd, gap_cost: Simd, gap_cost_lane: P
 
 #[target_feature(enable = "avx2")]
 #[inline]
-#[allow(non_snake_case)]
-pub unsafe fn simd_prefix_scan_gaps_i16(R_max: Simd, gap_cost: Simd) -> (Simd, Simd) {
-    let mut shift1 = simd_sllz_i16!(R_max, 1);
-    shift1 = _mm256_adds_epi16(shift1, gap_cost);
-    shift1 = _mm256_max_epi16(R_max, shift1);
-
-    let mut gap_shift1 = simd_sllz_i16!(gap_cost, 1);
-    gap_shift1 = _mm256_adds_epi16(gap_shift1, gap_cost);
-    let mut shift2 = simd_sllz_i16!(shift1, 2);
-    shift2 = _mm256_adds_epi16(shift2, gap_shift1);
-    shift2 = _mm256_max_epi16(shift1, shift2);
-
-    let mut gap_shift2 = simd_sllz_i16!(gap_shift1, 2);
-    gap_shift2 = _mm256_adds_epi16(gap_shift2, gap_shift1);
-    let mut shift4 = simd_sllz_i16!(shift2, 4);
-    shift4 = _mm256_adds_epi16(shift4, gap_shift2);
-    shift4 = _mm256_max_epi16(shift2, shift4);
-
-    let mut gap_shift4 = simd_sllz_i16!(gap_shift2, 4);
-    gap_shift4 = _mm256_adds_epi16(gap_shift4, gap_shift2);
-
-    // Correct the upper lane using the last element of the lower lane
-    // Make sure that the operation on the bottom lane is essentially nop
-    let mut correct1 = _mm256_shufflehi_epi16(shift4, 0b11111111);
-    correct1 = _mm256_permute4x64_epi64(correct1, 0b01010000);
-    correct1 = _mm256_adds_epi16(correct1, gap_shift4);
-    correct1 = _mm256_max_epi16(shift4, correct1);
-
-    let mut gap_correct1 = _mm256_srli_si256(_mm256_shufflehi_epi16(gap_shift4, 0b11111111), 8);
-    gap_correct1 = _mm256_permute4x64_epi64(gap_correct1, 0b00000101);
-    gap_correct1 = _mm256_adds_epi16(gap_correct1, gap_shift4);
-
-    (correct1, gap_correct1)
-}
-
-#[target_feature(enable = "avx2")]
-#[inline]
 pub unsafe fn halfsimd_lookup2_i16(lut1: HalfSimd, lut2: HalfSimd, v: HalfSimd) -> Simd {
     let a = _mm_shuffle_epi8(lut1, v);
     let b = _mm_shuffle_epi8(lut2, v);

--- a/src/avx2.rs
+++ b/src/avx2.rs
@@ -322,6 +322,43 @@ pub unsafe fn simd_prefix_scan_i16(R_max: Simd, gap_cost: Simd, gap_cost_lane: P
 
 #[target_feature(enable = "avx2")]
 #[inline]
+#[allow(non_snake_case)]
+pub unsafe fn simd_prefix_scan_gaps_i16(R_max: Simd, gap_cost: Simd) -> (Simd, Simd) {
+    let mut shift1 = simd_sllz_i16!(R_max, 1);
+    shift1 = _mm256_adds_epi16(shift1, gap_cost);
+    shift1 = _mm256_max_epi16(R_max, shift1);
+
+    let mut gap_shift1 = simd_sllz_i16!(gap_cost, 1);
+    gap_shift1 = _mm256_adds_epi16(gap_shift1, gap_cost);
+    let mut shift2 = simd_sllz_i16!(shift1, 2);
+    shift2 = _mm256_adds_epi16(shift2, gap_shift1);
+    shift2 = _mm256_max_epi16(shift1, shift2);
+
+    let mut gap_shift2 = simd_sllz_i16!(gap_shift1, 2);
+    gap_shift2 = _mm256_adds_epi16(gap_shift2, gap_shift1);
+    let mut shift4 = simd_sllz_i16!(shift2, 4);
+    shift4 = _mm256_adds_epi16(shift4, gap_shift2);
+    shift4 = _mm256_max_epi16(shift2, shift4);
+
+    let mut gap_shift4 = simd_sllz_i16!(gap_shift2, 4);
+    gap_shift4 = _mm256_adds_epi16(gap_shift4, gap_shift2);
+
+    // Correct the upper lane using the last element of the lower lane
+    // Make sure that the operation on the bottom lane is essentially nop
+    let mut correct1 = _mm256_shufflehi_epi16(shift4, 0b11111111);
+    correct1 = _mm256_permute4x64_epi64(correct1, 0b01010000);
+    correct1 = _mm256_adds_epi16(correct1, gap_shift4);
+    correct1 = _mm256_max_epi16(shift4, correct1);
+
+    let mut gap_correct1 = _mm256_srli_si256(_mm256_shufflehi_epi16(gap_shift4, 0b11111111), 8);
+    gap_correct1 = _mm256_permute4x64_epi64(gap_correct1, 0b00000101);
+    gap_correct1 = _mm256_adds_epi16(gap_correct1, gap_shift4);
+
+    (correct1, gap_correct1)
+}
+
+#[target_feature(enable = "avx2")]
+#[inline]
 pub unsafe fn halfsimd_lookup2_i16(lut1: HalfSimd, lut2: HalfSimd, v: HalfSimd) -> Simd {
     let a = _mm_shuffle_epi8(lut1, v);
     let b = _mm_shuffle_epi8(lut2, v);

--- a/src/avx2.rs
+++ b/src/avx2.rs
@@ -48,6 +48,10 @@ pub unsafe fn simd_load(ptr: *const Simd) -> Simd { _mm256_load_si256(ptr) }
 
 #[target_feature(enable = "avx2")]
 #[inline]
+pub unsafe fn simd_loadu(ptr: *const Simd) -> Simd { _mm256_loadu_si256(ptr) }
+
+#[target_feature(enable = "avx2")]
+#[inline]
 pub unsafe fn simd_store(ptr: *mut Simd, a: Simd) { _mm256_store_si256(ptr, a) }
 
 #[target_feature(enable = "avx2")]
@@ -447,13 +451,15 @@ mod tests {
             struct A([i16; L]);
 
             let vec = A([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 12, 13, 14, 11]);
-            let consts = get_prefix_scan_consts(0);
-            let res = simd_prefix_scan_i16(simd_load(vec.0.as_ptr() as *const Simd), consts);
+            let gap = simd_set1_i16(0);
+            let (_, consts) = get_prefix_scan_consts(gap);
+            let res = simd_prefix_scan_i16(simd_load(vec.0.as_ptr() as *const Simd), gap, consts);
             simd_assert_vec_eq(res, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 15, 15, 15, 15]);
 
             let vec = A([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 12, 13, 14, 11]);
-            let consts = get_prefix_scan_consts(-1);
-            let res = simd_prefix_scan_i16(simd_load(vec.0.as_ptr() as *const Simd), consts);
+            let gap = simd_set1_i16(-1);
+            let (_, consts) = get_prefix_scan_consts(gap);
+            let res = simd_prefix_scan_i16(simd_load(vec.0.as_ptr() as *const Simd), gap, consts);
             simd_assert_vec_eq(res, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 14, 13, 14, 13]);
         }
         unsafe { inner(); }

--- a/src/avx2.rs
+++ b/src/avx2.rs
@@ -261,7 +261,7 @@ pub unsafe fn simd_hargmax_i16(v: Simd, max: i16) -> usize {
 #[inline]
 #[allow(non_snake_case)]
 #[allow(dead_code)]
-pub unsafe fn simd_naive_prefix_scan_i16(R_max: Simd, (gap_cost, _gap_cost12345678): PrefixScanConsts) -> Simd {
+pub unsafe fn simd_naive_prefix_scan_i16(R_max: Simd, gap_cost: Simd, _gap_cost_lane: PrefixScanConsts) -> Simd {
     let mut curr = R_max;
 
     for _i in 0..(L - 1) {
@@ -274,36 +274,29 @@ pub unsafe fn simd_naive_prefix_scan_i16(R_max: Simd, (gap_cost, _gap_cost123456
     curr
 }
 
-#[target_feature(enable = "avx2")]
-#[inline]
-pub unsafe fn get_gap_extend_all(gap: i16) -> Simd {
-    _mm256_set_epi16(
-        gap * 16, gap * 15, gap * 14, gap * 13,
-        gap * 12, gap * 11, gap * 10, gap * 9,
-        gap * 8, gap * 7, gap * 6, gap * 5,
-        gap * 4, gap * 3, gap * 2, gap * 1
-    )
-}
-
-pub type PrefixScanConsts = (Simd, Simd);
+pub type PrefixScanConsts = Simd;
 
 #[target_feature(enable = "avx2")]
 #[inline]
-pub unsafe fn get_prefix_scan_consts(gap: i16) -> PrefixScanConsts {
-    let gap_cost = _mm256_set1_epi16(gap);
-    let gap_cost12345678 = _mm256_set_epi16(
-        gap * 8, gap * 7, gap * 6, gap * 5,
-        gap * 4, gap * 3, gap * 2, gap * 1,
-        gap * 8, gap * 7, gap * 6, gap * 5,
-        gap * 4, gap * 3, gap * 2, gap * 1
-    );
-    (gap_cost, gap_cost12345678)
+pub unsafe fn get_prefix_scan_consts(gap: Simd) -> (Simd, PrefixScanConsts) {
+    let mut shift1 = simd_sllz_i16!(gap, 1);
+    shift1 = _mm256_adds_epi16(shift1, gap);
+    let mut shift2 = simd_sllz_i16!(shift1, 2);
+    shift2 = _mm256_adds_epi16(shift2, shift1);
+    let mut shift4 = simd_sllz_i16!(shift2, 4);
+    shift4 = _mm256_adds_epi16(shift4, shift2);
+
+    let mut correct1 = _mm256_srli_si256(_mm256_shufflehi_epi16(shift4, 0b11111111), 8);
+    correct1 = _mm256_permute4x64_epi64(correct1, 0b00000101);
+    correct1 = _mm256_adds_epi16(correct1, shift4);
+
+    (correct1, shift4)
 }
 
 #[target_feature(enable = "avx2")]
 #[inline]
 #[allow(non_snake_case)]
-pub unsafe fn simd_prefix_scan_i16(R_max: Simd, (gap_cost, gap_cost12345678): PrefixScanConsts) -> Simd {
+pub unsafe fn simd_prefix_scan_i16(R_max: Simd, gap_cost: Simd, gap_cost_lane: PrefixScanConsts) -> Simd {
     // Optimized prefix add and max for every eight elements
     // Note: be very careful to avoid lane-crossing which has a large penalty.
     // Also, make sure to use as little registers as possible to avoid
@@ -323,7 +316,7 @@ pub unsafe fn simd_prefix_scan_i16(R_max: Simd, (gap_cost, gap_cost12345678): Pr
     // Make sure that the operation on the bottom lane is essentially nop
     let mut correct1 = _mm256_shufflehi_epi16(shift4, 0b11111111);
     correct1 = _mm256_permute4x64_epi64(correct1, 0b01010000);
-    correct1 = _mm256_adds_epi16(correct1, gap_cost12345678);
+    correct1 = _mm256_adds_epi16(correct1, gap_cost_lane);
     _mm256_max_epi16(shift4, correct1)
 }
 

--- a/src/scan_block.rs
+++ b/src/scan_block.rs
@@ -683,8 +683,8 @@ macro_rules! place_block_profile_gen {
                 ptr::write(D_row.add(j), simd_extract_i16!(D11, L - 1));
                 ptr::write(R_row.add(j), simd_extract_i16!(R11, L - 1));
 
-                if !X_DROP && start_i + height > $q.len()
-                    && start_j + j >= $r.len() {
+                if !X_DROP && start_i + height > $query.len()
+                    && start_j + j >= $reference.len() {
                     if TRACE {
                         // make sure that the trace index is updated since the rest of the loop
                         // iterations are skipped
@@ -1700,6 +1700,15 @@ mod tests {
         let r = PaddedBytes::from_bytes::<ByteMatrix>(b"abcdefg", 16);
         let q = PaddedBytes::from_bytes::<ByteMatrix>(b"abdefg", 16);
         a.align(&q, &r, &BYTES1, test_gaps, 16..=16, 0);
+        assert_eq!(a.res().score, 4);
+    }
+
+    #[test]
+    fn test_profile() {
+        let mut a = Block::<false, false>::new(100, 100, 16);
+        let r = AAProfile::from_bytes(b"AAAA", 16, 1, -1, -1, 0, -1, -1);
+        let q = PaddedBytes::from_bytes::<AAMatrix>(b"AAAA", 16);
+        a.align_profile(&q, &r, 16..=16, 0);
         assert_eq!(a.res().score, 4);
     }
 }

--- a/src/scan_block.rs
+++ b/src/scan_block.rs
@@ -61,7 +61,7 @@ struct State<'a, M: Matrix> {
 struct StateProfile<'a, P: Profile> {
     query: &'a PaddedBytes,
     i: usize,
-    reference: &'a Profile,
+    reference: &'a P,
     j: usize,
     min_size: usize,
     max_size: usize,
@@ -72,6 +72,631 @@ struct StateProfile<'a, P: Profile> {
 pub struct Block<const TRACE: bool, const X_DROP: bool> {
     res: AlignResult,
     allocated: Allocated
+}
+
+macro_rules! align_core_gen {
+    ($fn_name:ident, $matrix_or_profile:tt, $state:tt, $place_block_right_fn:path, $place_block_down_fn:path) => {
+        #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+        #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+        #[allow(non_snake_case)]
+        unsafe fn $fn_name<M: $matrix_or_profile>(&mut self, mut state: $state<M>) {
+            // store the best alignment ending location for x drop alignment
+            let mut best_max = 0i32;
+            let mut best_argmax_i = 0usize;
+            let mut best_argmax_j = 0usize;
+
+            let mut prev_dir = Direction::Grow;
+            let mut dir = Direction::Grow;
+            let mut prev_size = 0;
+            let mut block_size = state.min_size;
+            let mut step = STEP;
+
+            // 32-bit score offsets
+            let mut off = 0i32;
+            let mut prev_off;
+            let mut off_max = 0i32;
+
+            // how many steps since the latest best score was encountered
+            let mut y_drop_iter = 0;
+
+            // how many steps where the X-drop threshold is met
+            let mut x_drop_iter = 0;
+
+            let mut i_ckpt = state.i;
+            let mut j_ckpt = state.j;
+            let mut off_ckpt = 0i32;
+
+            // corner value that affects the score when shifting down then right, or right then down
+            let mut D_corner = simd_set1_i16(MIN);
+
+            loop {
+                #[cfg(feature = "debug")]
+                {
+                    println!("i: {}", state.i);
+                    println!("j: {}", state.j);
+                    println!("{:?}", dir);
+                    println!("block size: {}", block_size);
+                }
+
+                prev_off = off;
+                let mut grow_D_max = simd_set1_i16(MIN);
+                let mut grow_D_argmax = simd_set1_i16(0);
+                let (D_max, D_argmax, mut right_max, mut down_max) = match dir {
+                    Direction::Right => {
+                        off = off_max;
+                        #[cfg(feature = "debug")]
+                        println!("off: {}", off);
+                        let off_add = simd_set1_i16(clamp(prev_off - off));
+
+                        if TRACE {
+                            self.allocated.trace.add_block(state.i, state.j + block_size - step, step, block_size, true);
+                        }
+
+                        // offset previous columns with newly computed offset
+                        Self::just_offset(block_size, self.allocated.D_col.as_mut_ptr(), self.allocated.C_col.as_mut_ptr(), off_add);
+
+                        // compute new elements in the block as a result of shifting by the step size
+                        // this region should be block_size x step
+                        let (D_max, D_argmax) = $place_block_right_fn(
+                            &state,
+                            state.query,
+                            state.reference,
+                            &mut self.allocated.trace,
+                            state.i,
+                            state.j + block_size - step,
+                            step,
+                            block_size,
+                            self.allocated.D_col.as_mut_ptr(),
+                            self.allocated.C_col.as_mut_ptr(),
+                            self.allocated.temp_buf1.as_mut_ptr(),
+                            self.allocated.temp_buf2.as_mut_ptr(),
+                            if prev_dir == Direction::Down { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
+                            true
+                        );
+
+                        // sum of a couple elements on the right border
+                        let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
+
+                        // shift and offset bottom row
+                        D_corner = Self::shift_and_offset(
+                            block_size,
+                            self.allocated.D_row.as_mut_ptr(),
+                            self.allocated.R_row.as_mut_ptr(),
+                            self.allocated.temp_buf1.as_mut_ptr(),
+                            self.allocated.temp_buf2.as_mut_ptr(),
+                            off_add,
+                            step
+                        );
+                        // sum of a couple elements on the bottom border
+                        let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
+
+                        (D_max, D_argmax, right_max, down_max)
+                    },
+                    Direction::Down => {
+                        off = off_max;
+                        #[cfg(feature = "debug")]
+                        println!("off: {}", off);
+                        let off_add = simd_set1_i16(clamp(prev_off - off));
+
+                        if TRACE {
+                            self.allocated.trace.add_block(state.i + block_size - step, state.j, block_size, step, false);
+                        }
+
+                        // offset previous rows with newly computed offset
+                        Self::just_offset(block_size, self.allocated.D_row.as_mut_ptr(), self.allocated.R_row.as_mut_ptr(), off_add);
+
+                        // compute new elements in the block as a result of shifting by the step size
+                        // this region should be step x block_size
+                        let (D_max, D_argmax) = $place_block_down_fn(
+                            &state,
+                            state.reference,
+                            state.query,
+                            &mut self.allocated.trace,
+                            state.j,
+                            state.i + block_size - step,
+                            step,
+                            block_size,
+                            self.allocated.D_row.as_mut_ptr(),
+                            self.allocated.R_row.as_mut_ptr(),
+                            self.allocated.temp_buf1.as_mut_ptr(),
+                            self.allocated.temp_buf2.as_mut_ptr(),
+                            if prev_dir == Direction::Right { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
+                            false
+                        );
+
+                        // sum of a couple elements on the bottom border
+                        let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
+
+                        // shift and offset last column
+                        D_corner = Self::shift_and_offset(
+                            block_size,
+                            self.allocated.D_col.as_mut_ptr(),
+                            self.allocated.C_col.as_mut_ptr(),
+                            self.allocated.temp_buf1.as_mut_ptr(),
+                            self.allocated.temp_buf2.as_mut_ptr(),
+                            off_add,
+                            step
+                        );
+                        // sum of a couple elements on the right border
+                        let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
+
+                        (D_max, D_argmax, right_max, down_max)
+                    },
+                    Direction::Grow => {
+                        D_corner = simd_set1_i16(MIN);
+                        let grow_step = block_size - prev_size;
+
+                        #[cfg(feature = "debug")]
+                        println!("off: {}", off);
+                        #[cfg(feature = "debug")]
+                        println!("Grow down");
+
+                        if TRACE {
+                            self.allocated.trace.add_block(state.i + prev_size, state.j, prev_size, grow_step, false);
+                        }
+
+                        // down
+                        // this region should be prev_size x prev_size
+                        let (D_max1, D_argmax1) = $place_block_down_fn(
+                            &state,
+                            state.reference,
+                            state.query,
+                            &mut self.allocated.trace,
+                            state.j,
+                            state.i + prev_size,
+                            grow_step,
+                            prev_size,
+                            self.allocated.D_row.as_mut_ptr(),
+                            self.allocated.R_row.as_mut_ptr(),
+                            self.allocated.D_col.as_mut_ptr().add(prev_size),
+                            self.allocated.C_col.as_mut_ptr().add(prev_size),
+                            simd_set1_i16(MIN),
+                            false
+                        );
+
+                        #[cfg(feature = "debug")]
+                        println!("Grow right");
+
+                        if TRACE {
+                            self.allocated.trace.add_block(state.i, state.j + prev_size, grow_step, block_size, true);
+                        }
+
+                        // right
+                        // this region should be block_size x prev_size
+                        let (D_max2, D_argmax2) = $place_block_right_fn(
+                            &state,
+                            state.query,
+                            state.reference,
+                            &mut self.allocated.trace,
+                            state.i,
+                            state.j + prev_size,
+                            grow_step,
+                            block_size,
+                            self.allocated.D_col.as_mut_ptr(),
+                            self.allocated.C_col.as_mut_ptr(),
+                            self.allocated.D_row.as_mut_ptr().add(prev_size),
+                            self.allocated.R_row.as_mut_ptr().add(prev_size),
+                            simd_set1_i16(MIN),
+                            true
+                        );
+
+                        let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
+                        let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
+                        grow_D_max = D_max1;
+                        grow_D_argmax = D_argmax1;
+
+                        // must update the checkpoint saved values just in case
+                        // the block must grow again from this position
+                        let mut i = 0;
+                        while i < block_size {
+                            self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
+                            self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
+                            self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
+                            self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
+                            i += L;
+                        }
+
+                        if TRACE {
+                            self.allocated.trace.save_ckpt();
+                        }
+
+                        (D_max2, D_argmax2, right_max, down_max)
+                    }
+                };
+
+                prev_dir = dir;
+                let D_max_max = simd_hmax_i16(D_max);
+                // grow max is an auxiliary value used when growing because it requires two separate
+                // place_block steps
+                let grow_max = simd_hmax_i16(grow_D_max);
+                // max score of the entire block
+                let max = cmp::max(D_max_max, grow_max);
+                off_max = off + (max as i32) - (ZERO as i32);
+                #[cfg(feature = "debug")]
+                println!("down max: {}, right max: {}", down_max, right_max);
+
+                y_drop_iter += 1;
+                // if block grows but the best score does not improve, then the block must grow again
+                let mut grow_no_max = dir == Direction::Grow;
+
+                if off_max > best_max {
+                    if X_DROP {
+                        // TODO: move outside loop
+                        // calculate location with the best score
+                        let lane_idx = simd_hargmax_i16(D_max, D_max_max);
+                        let idx = simd_slow_extract_i16(D_argmax, lane_idx) as usize;
+                        let r = (idx % (block_size / L)) * L + lane_idx;
+                        let c = (block_size - step) + idx / (block_size / L);
+
+                        match dir {
+                            Direction::Right => {
+                                best_argmax_i = state.i + r;
+                                best_argmax_j = state.j + c;
+                            },
+                            Direction::Down => {
+                                best_argmax_i = state.i + c;
+                                best_argmax_j = state.j + r;
+                            },
+                            Direction::Grow => {
+                                // max could be in either block
+                                if max >= grow_max {
+                                    best_argmax_i = state.i + (idx % (block_size / L)) * L + lane_idx;
+                                    best_argmax_j = state.j + prev_size + idx / (block_size / L);
+                                } else {
+                                    let lane_idx = simd_hargmax_i16(grow_D_max, grow_max);
+                                    let idx = simd_slow_extract_i16(grow_D_argmax, lane_idx) as usize;
+                                    best_argmax_i = state.i + prev_size + idx / (prev_size / L);
+                                    best_argmax_j = state.j + (idx % (prev_size / L)) * L + lane_idx;
+                                }
+                            }
+                        }
+                    }
+
+                    if block_size < state.max_size {
+                        // if able to grow in the future, then save the current location
+                        // as a checkpoint
+                        i_ckpt = state.i;
+                        j_ckpt = state.j;
+                        off_ckpt = off;
+
+                        let mut i = 0;
+                        while i < block_size {
+                            self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
+                            self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
+                            self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
+                            self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
+                            i += L;
+                        }
+
+                        if TRACE {
+                            self.allocated.trace.save_ckpt();
+                        }
+
+                        grow_no_max = false;
+                    }
+
+                    best_max = off_max;
+
+                    y_drop_iter = 0;
+                }
+
+                if X_DROP {
+                    if off_max < best_max - state.x_drop {
+                        if x_drop_iter < X_DROP_ITER - 1 {
+                            x_drop_iter += 1;
+                        } else {
+                            // x drop termination
+                            break;
+                        }
+                    } else {
+                        x_drop_iter = 0;
+                    }
+                }
+
+                if state.i + block_size > state.query.len() && state.j + block_size > state.reference.len() {
+                    // reached the end of the strings
+                    break;
+                }
+
+                // first check if the shift direction is "forced" to avoid going out of bounds
+                if state.j + block_size > state.reference.len() {
+                    state.i += step;
+                    dir = Direction::Down;
+                    continue;
+                }
+                if state.i + block_size > state.query.len() {
+                    state.j += step;
+                    dir = Direction::Right;
+                    continue;
+                }
+
+                // check if it is possible to grow
+                let next_size = if GROW_EXP { block_size * 2 } else { block_size + GROW_STEP };
+                if next_size <= state.max_size {
+                    // if approximately (block_size / step) iterations has passed since the last best
+                    // max, then it is time to grow
+                    if y_drop_iter > (block_size / step) - 1 || grow_no_max {
+                        // y drop grow block
+                        prev_size = block_size;
+                        block_size = next_size;
+                        dir = Direction::Grow;
+                        if STEP != LARGE_STEP && block_size >= (LARGE_STEP / STEP) * state.min_size {
+                            step = LARGE_STEP;
+                        }
+
+                        // return to checkpoint
+                        state.i = i_ckpt;
+                        state.j = j_ckpt;
+                        off = off_ckpt;
+
+                        let mut i = 0;
+                        while i < prev_size {
+                            self.allocated.D_col.set_vec(&self.allocated.D_col_ckpt, i);
+                            self.allocated.C_col.set_vec(&self.allocated.C_col_ckpt, i);
+                            self.allocated.D_row.set_vec(&self.allocated.D_row_ckpt, i);
+                            self.allocated.R_row.set_vec(&self.allocated.R_row_ckpt, i);
+                            i += L;
+                        }
+
+                        if TRACE {
+                            self.allocated.trace.restore_ckpt();
+                        }
+
+                        y_drop_iter = 0;
+                        continue;
+                    }
+                }
+
+                // check if it is possible to shrink
+                if SHRINK && block_size > state.min_size && y_drop_iter == 0 {
+                    let shrink_max = cmp::max(
+                        Self::suffix_max(self.allocated.D_row.as_ptr(), block_size, step),
+                        Self::suffix_max(self.allocated.D_col.as_ptr(), block_size, step)
+                    );
+                    if shrink_max >= max {
+                        // just to make sure it is not right or down shift so D_corner is not used
+                        prev_dir = Direction::Grow;
+
+                        block_size /= 2;
+                        let mut i = 0;
+                        while i < block_size {
+                            self.allocated.D_col.copy_vec(i, i + block_size);
+                            self.allocated.C_col.copy_vec(i, i + block_size);
+                            self.allocated.D_row.copy_vec(i, i + block_size);
+                            self.allocated.R_row.copy_vec(i, i + block_size);
+                            i += L;
+                        }
+
+                        state.i += block_size;
+                        state.j += block_size;
+
+                        i_ckpt = state.i;
+                        j_ckpt = state.j;
+                        off_ckpt = off;
+
+                        let mut i = 0;
+                        while i < block_size {
+                            self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
+                            self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
+                            self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
+                            self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
+                            i += L;
+                        }
+
+                        right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
+                        down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
+
+                        if TRACE {
+                            self.allocated.trace.save_ckpt();
+                        }
+
+                        y_drop_iter = 0;
+                    }
+                }
+
+                // move according to where the max is
+                if down_max > right_max {
+                    state.i += step;
+                    dir = Direction::Down;
+                } else {
+                    state.j += step;
+                    dir = Direction::Right;
+                }
+            }
+
+            #[cfg(any(feature = "debug", feature = "debug_size"))]
+            {
+                println!("query size: {}, reference size: {}", state.query.len(), state.reference.len());
+                println!("end block size: {}", block_size);
+            }
+
+            self.res = if X_DROP {
+                AlignResult {
+                    score: best_max,
+                    query_idx: best_argmax_i,
+                    reference_idx: best_argmax_j
+                }
+            } else {
+                debug_assert!(state.i <= state.query.len());
+                let score = off + match dir {
+                    Direction::Right | Direction::Grow => {
+                        let idx = state.query.len() - state.i;
+                        debug_assert!(idx < block_size);
+                        (self.allocated.D_col.get(idx) as i32) - (ZERO as i32)
+                    },
+                    Direction::Down => {
+                        let idx = state.reference.len() - state.j;
+                        debug_assert!(idx < block_size);
+                        (self.allocated.D_row.get(idx) as i32) - (ZERO as i32)
+                    }
+                };
+                AlignResult {
+                    score,
+                    query_idx: state.query.len(),
+                    reference_idx: state.reference.len()
+                }
+            };
+        }
+    };
+}
+
+/// Place block right or down for sequence-profile alignment.
+///
+/// Assumes all inputs are already relative to the current offset.
+///
+/// Inside this function, everything will be treated as shifting right,
+/// conceptually. The same process can be trivially used for shifting
+/// down by calling this function with different parameters.
+///
+/// Right and down shifts must be handled separately since a sequence
+/// is aligned to a profile.
+macro_rules! place_block_profile_gen {
+    ($fn_name:ident, $query: ident, $query_type: ty, $reference: ident, $reference_type: ty, $right: expr) => {
+        #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+        #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+        #[allow(non_snake_case)]
+        unsafe fn $fn_name<P: Profile>(state: &StateProfile<P>,
+                                       query: $query_type,
+                                       reference: $reference_type,
+                                       trace: &mut Trace,
+                                       start_i: usize,
+                                       start_j: usize,
+                                       width: usize,
+                                       height: usize,
+                                       D_col: *mut i16,
+                                       C_col: *mut i16,
+                                       D_row: *mut i16,
+                                       R_row: *mut i16,
+                                       mut D_corner: Simd,
+                                       _right: bool) -> (Simd, Simd) {
+            let gap_extend = simd_set1_i16($reference.get_gap_extend() as i16);
+            let (gap_extend_all, prefix_scan_consts) = get_prefix_scan_consts(gap_extend);
+            let mut D_max = simd_set1_i16(MIN);
+            let mut D_argmax = simd_set1_i16(0);
+            let mut curr_i = simd_set1_i16(0);
+
+            let mut idx = 0;
+            let mut gap_open_C = simd_set1_i16(MIN);
+            let mut gap_close_C = simd_set1_i16(MIN);
+            let mut gap_open_R = simd_set1_i16(MIN);
+            let mut gap_close_R = simd_set1_i16(MIN);
+
+            if width == 0 || height == 0 {
+                return (D_max, D_argmax);
+            }
+
+            // hottest loop in the whole program
+            for j in 0..width {
+                let mut R01 = simd_set1_i16(MIN);
+                let mut D11 = simd_set1_i16(MIN);
+                let mut R11 = simd_set1_i16(MIN);
+
+                if $right {
+                    idx = start_j + j;
+                    gap_open_C = $reference.get_gap_open_right_C(idx);
+                    gap_close_C = $reference.get_gap_close_right_C(idx);
+                    gap_open_R = $reference.get_gap_open_right_R(idx);
+                }
+
+                let mut i = 0;
+                while i < height {
+                    let D10 = simd_load(D_col.add(i) as _);
+                    let C10 = simd_load(C_col.add(i) as _);
+                    let D00 = simd_sl_i16!(D10, D_corner, 1);
+                    D_corner = D10;
+
+                    if !$right {
+                        idx = start_i + i;
+                        gap_open_C = $reference.get_gap_open_down_R(idx);
+                        gap_open_R = $reference.get_gap_open_down_C(idx);
+                        gap_close_R = $reference.get_gap_close_down_C(idx);
+                    }
+
+                    let scores = if $right {
+                        $reference.get_scores_pos(idx, halfsimd_loadu($query.as_ptr(start_i + i) as _), true)
+                    } else {
+                        $reference.get_scores_aa(idx, $query.get(start_j + j), false)
+                    };
+                    D11 = simd_adds_i16(D00, scores);
+                    if start_i + i == 0 && start_j + j == 0 {
+                        D11 = simd_insert_i16!(D11, ZERO, 0);
+                    }
+
+                    let C11 = simd_max_i16(simd_adds_i16(C10, gap_extend), simd_adds_i16(D10, simd_adds_i16(gap_open_C, gap_extend)));
+                    D11 = simd_max_i16(D11, if $right { simd_adds_i16(C11, gap_close_C) } else { C11 });
+                    // at this point, C11 is fully calculated and D11 is partially calculated
+
+                    let D11_open = simd_adds_i16(D11, gap_open_R);
+                    R11 = simd_prefix_scan_i16(D11_open, gap_extend, prefix_scan_consts);
+                    // do prefix scan before using R01 to break up dependency chain that depends on
+                    // the last element of R01 from the previous loop iteration
+                    R11 = simd_max_i16(R11, simd_adds_i16(simd_broadcasthi_i16(R01), gap_extend_all));
+                    // fully calculate D11 using R11
+                    D11 = simd_max_i16(D11, if $right { R11 } else { simd_adds_i16(R11, gap_close_R) });
+                    R01 = R11;
+
+                    #[cfg(feature = "debug")]
+                    {
+                        print!("s:   ");
+                        simd_dbg_i16(scores);
+                        print!("D00: ");
+                        simd_dbg_i16(simd_subs_i16(D00, simd_set1_i16(ZERO)));
+                        print!("C11: ");
+                        simd_dbg_i16(simd_subs_i16(C11, simd_set1_i16(ZERO)));
+                        print!("R11: ");
+                        simd_dbg_i16(simd_subs_i16(R11, simd_set1_i16(ZERO)));
+                        print!("D11: ");
+                        simd_dbg_i16(simd_subs_i16(D11, simd_set1_i16(ZERO)));
+                    }
+
+                    if TRACE {
+                        let trace_D_C = simd_cmpeq_i16(D11, C11);
+                        let trace_D_R = simd_cmpeq_i16(D11, R11);
+                        #[cfg(feature = "debug")]
+                        {
+                            print!("D_C: ");
+                            simd_dbg_i16(trace_D_C);
+                            print!("D_R: ");
+                            simd_dbg_i16(trace_D_R);
+                        }
+                        // compress trace with movemask to save space
+                        let trace_data = simd_movemask_i8(simd_blend_i8(trace_D_C, trace_D_R, simd_set1_i16(0xFF00u16 as i16)));
+                        trace.add_trace(trace_data as TraceType);
+                    }
+
+                    D_max = simd_max_i16(D_max, D11);
+
+                    if X_DROP {
+                        // keep track of the best score and its location
+                        let mask = simd_cmpeq_i16(D_max, D11);
+                        D_argmax = simd_blend_i8(D_argmax, curr_i, mask);
+                        curr_i = simd_adds_i16(curr_i, simd_set1_i16(1));
+                    }
+
+                    simd_store(D_col.add(i) as _, D11);
+                    simd_store(C_col.add(i) as _, C11);
+                    i += L;
+                }
+
+                D_corner = simd_set1_i16(MIN);
+
+                ptr::write(D_row.add(j), simd_extract_i16!(D11, L - 1));
+                ptr::write(R_row.add(j), simd_extract_i16!(R11, L - 1));
+
+                if !X_DROP && start_i + height > $query.len()
+                    && start_j + j >= $reference.len() {
+                    if TRACE {
+                        // make sure that the trace index is updated since the rest of the loop
+                        // iterations are skipped
+                        trace.add_trace_idx((width - 1 - j) * (height / L));
+                    }
+                    break;
+                }
+            }
+
+            (D_max, D_argmax)
+        }
+    };
 }
 
 // increasing step size gives a bit extra speed but results in lower accuracy
@@ -211,474 +836,8 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
         unsafe { self.align_profile_core(s); }
     }
 
-    macro_rules! align_core_gen {
-        ($fn_name:ident, $matrix_or_profile:ty, $state:ty, $place_block_right_fn:path, $place_block_down_fn:path) => {
-            #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
-            #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
-            #[allow(non_snake_case)]
-            unsafe fn $fn_name<M: $matrix_or_profile>(&mut self, mut state: $state<M>) {
-                // store the best alignment ending location for x drop alignment
-                let mut best_max = 0i32;
-                let mut best_argmax_i = 0usize;
-                let mut best_argmax_j = 0usize;
-
-                let mut prev_dir = Direction::Grow;
-                let mut dir = Direction::Grow;
-                let mut prev_size = 0;
-                let mut block_size = state.min_size;
-                let mut step = STEP;
-
-                // 32-bit score offsets
-                let mut off = 0i32;
-                let mut prev_off;
-                let mut off_max = 0i32;
-
-                // how many steps since the latest best score was encountered
-                let mut y_drop_iter = 0;
-
-                // how many steps where the X-drop threshold is met
-                let mut x_drop_iter = 0;
-
-                let mut i_ckpt = state.i;
-                let mut j_ckpt = state.j;
-                let mut off_ckpt = 0i32;
-
-                // corner value that affects the score when shifting down then right, or right then down
-                let mut D_corner = simd_set1_i16(MIN);
-
-                loop {
-                    #[cfg(feature = "debug")]
-                    {
-                        println!("i: {}", state.i);
-                        println!("j: {}", state.j);
-                        println!("{:?}", dir);
-                        println!("block size: {}", block_size);
-                    }
-
-                    prev_off = off;
-                    let mut grow_D_max = simd_set1_i16(MIN);
-                    let mut grow_D_argmax = simd_set1_i16(0);
-                    let (D_max, D_argmax, mut right_max, mut down_max) = match dir {
-                        Direction::Right => {
-                            off = off_max;
-                            #[cfg(feature = "debug")]
-                            println!("off: {}", off);
-                            let off_add = simd_set1_i16(clamp(prev_off - off));
-
-                            if TRACE {
-                                self.allocated.trace.add_block(state.i, state.j + block_size - step, step, block_size, true);
-                            }
-
-                            // offset previous columns with newly computed offset
-                            Self::just_offset(block_size, self.allocated.D_col.as_mut_ptr(), self.allocated.C_col.as_mut_ptr(), off_add);
-
-                            // compute new elements in the block as a result of shifting by the step size
-                            // this region should be block_size x step
-                            let (D_max, D_argmax) = $place_block_right_fn(
-                                &state,
-                                state.query,
-                                state.reference,
-                                &mut self.allocated.trace,
-                                state.i,
-                                state.j + block_size - step,
-                                step,
-                                block_size,
-                                self.allocated.D_col.as_mut_ptr(),
-                                self.allocated.C_col.as_mut_ptr(),
-                                self.allocated.temp_buf1.as_mut_ptr(),
-                                self.allocated.temp_buf2.as_mut_ptr(),
-                                if prev_dir == Direction::Down { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
-                                true
-                            );
-
-                            // sum of a couple elements on the right border
-                            let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
-
-                            // shift and offset bottom row
-                            D_corner = Self::shift_and_offset(
-                                block_size,
-                                self.allocated.D_row.as_mut_ptr(),
-                                self.allocated.R_row.as_mut_ptr(),
-                                self.allocated.temp_buf1.as_mut_ptr(),
-                                self.allocated.temp_buf2.as_mut_ptr(),
-                                off_add,
-                                step
-                            );
-                            // sum of a couple elements on the bottom border
-                            let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
-
-                            (D_max, D_argmax, right_max, down_max)
-                        },
-                        Direction::Down => {
-                            off = off_max;
-                            #[cfg(feature = "debug")]
-                            println!("off: {}", off);
-                            let off_add = simd_set1_i16(clamp(prev_off - off));
-
-                            if TRACE {
-                                self.allocated.trace.add_block(state.i + block_size - step, state.j, block_size, step, false);
-                            }
-
-                            // offset previous rows with newly computed offset
-                            Self::just_offset(block_size, self.allocated.D_row.as_mut_ptr(), self.allocated.R_row.as_mut_ptr(), off_add);
-
-                            // compute new elements in the block as a result of shifting by the step size
-                            // this region should be step x block_size
-                            let (D_max, D_argmax) = $place_block_down_fn(
-                                &state,
-                                state.reference,
-                                state.query,
-                                &mut self.allocated.trace,
-                                state.j,
-                                state.i + block_size - step,
-                                step,
-                                block_size,
-                                self.allocated.D_row.as_mut_ptr(),
-                                self.allocated.R_row.as_mut_ptr(),
-                                self.allocated.temp_buf1.as_mut_ptr(),
-                                self.allocated.temp_buf2.as_mut_ptr(),
-                                if prev_dir == Direction::Right { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
-                                false
-                            );
-
-                            // sum of a couple elements on the bottom border
-                            let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
-
-                            // shift and offset last column
-                            D_corner = Self::shift_and_offset(
-                                block_size,
-                                self.allocated.D_col.as_mut_ptr(),
-                                self.allocated.C_col.as_mut_ptr(),
-                                self.allocated.temp_buf1.as_mut_ptr(),
-                                self.allocated.temp_buf2.as_mut_ptr(),
-                                off_add,
-                                step
-                            );
-                            // sum of a couple elements on the right border
-                            let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
-
-                            (D_max, D_argmax, right_max, down_max)
-                        },
-                        Direction::Grow => {
-                            D_corner = simd_set1_i16(MIN);
-                            let grow_step = block_size - prev_size;
-
-                            #[cfg(feature = "debug")]
-                            println!("off: {}", off);
-                            #[cfg(feature = "debug")]
-                            println!("Grow down");
-
-                            if TRACE {
-                                self.allocated.trace.add_block(state.i + prev_size, state.j, prev_size, grow_step, false);
-                            }
-
-                            // down
-                            // this region should be prev_size x prev_size
-                            let (D_max1, D_argmax1) = $place_block_down_fn(
-                                &state,
-                                state.reference,
-                                state.query,
-                                &mut self.allocated.trace,
-                                state.j,
-                                state.i + prev_size,
-                                grow_step,
-                                prev_size,
-                                self.allocated.D_row.as_mut_ptr(),
-                                self.allocated.R_row.as_mut_ptr(),
-                                self.allocated.D_col.as_mut_ptr().add(prev_size),
-                                self.allocated.C_col.as_mut_ptr().add(prev_size),
-                                simd_set1_i16(MIN),
-                                false
-                            );
-
-                            #[cfg(feature = "debug")]
-                            println!("Grow right");
-
-                            if TRACE {
-                                self.allocated.trace.add_block(state.i, state.j + prev_size, grow_step, block_size, true);
-                            }
-
-                            // right
-                            // this region should be block_size x prev_size
-                            let (D_max2, D_argmax2) = $place_block_right_fn(
-                                &state,
-                                state.query,
-                                state.reference,
-                                &mut self.allocated.trace,
-                                state.i,
-                                state.j + prev_size,
-                                grow_step,
-                                block_size,
-                                self.allocated.D_col.as_mut_ptr(),
-                                self.allocated.C_col.as_mut_ptr(),
-                                self.allocated.D_row.as_mut_ptr().add(prev_size),
-                                self.allocated.R_row.as_mut_ptr().add(prev_size),
-                                simd_set1_i16(MIN),
-                                true
-                            );
-
-                            let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
-                            let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
-                            grow_D_max = D_max1;
-                            grow_D_argmax = D_argmax1;
-
-                            // must update the checkpoint saved values just in case
-                            // the block must grow again from this position
-                            let mut i = 0;
-                            while i < block_size {
-                                self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
-                                self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
-                                self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
-                                self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
-                                i += L;
-                            }
-
-                            if TRACE {
-                                self.allocated.trace.save_ckpt();
-                            }
-
-                            (D_max2, D_argmax2, right_max, down_max)
-                        }
-                    };
-
-                    prev_dir = dir;
-                    let D_max_max = simd_hmax_i16(D_max);
-                    // grow max is an auxiliary value used when growing because it requires two separate
-                    // place_block steps
-                    let grow_max = simd_hmax_i16(grow_D_max);
-                    // max score of the entire block
-                    let max = cmp::max(D_max_max, grow_max);
-                    off_max = off + (max as i32) - (ZERO as i32);
-                    #[cfg(feature = "debug")]
-                    println!("down max: {}, right max: {}", down_max, right_max);
-
-                    y_drop_iter += 1;
-                    // if block grows but the best score does not improve, then the block must grow again
-                    let mut grow_no_max = dir == Direction::Grow;
-
-                    if off_max > best_max {
-                        if X_DROP {
-                            // TODO: move outside loop
-                            // calculate location with the best score
-                            let lane_idx = simd_hargmax_i16(D_max, D_max_max);
-                            let idx = simd_slow_extract_i16(D_argmax, lane_idx) as usize;
-                            let r = (idx % (block_size / L)) * L + lane_idx;
-                            let c = (block_size - step) + idx / (block_size / L);
-
-                            match dir {
-                                Direction::Right => {
-                                    best_argmax_i = state.i + r;
-                                    best_argmax_j = state.j + c;
-                                },
-                                Direction::Down => {
-                                    best_argmax_i = state.i + c;
-                                    best_argmax_j = state.j + r;
-                                },
-                                Direction::Grow => {
-                                    // max could be in either block
-                                    if max >= grow_max {
-                                        best_argmax_i = state.i + (idx % (block_size / L)) * L + lane_idx;
-                                        best_argmax_j = state.j + prev_size + idx / (block_size / L);
-                                    } else {
-                                        let lane_idx = simd_hargmax_i16(grow_D_max, grow_max);
-                                        let idx = simd_slow_extract_i16(grow_D_argmax, lane_idx) as usize;
-                                        best_argmax_i = state.i + prev_size + idx / (prev_size / L);
-                                        best_argmax_j = state.j + (idx % (prev_size / L)) * L + lane_idx;
-                                    }
-                                }
-                            }
-                        }
-
-                        if block_size < state.max_size {
-                            // if able to grow in the future, then save the current location
-                            // as a checkpoint
-                            i_ckpt = state.i;
-                            j_ckpt = state.j;
-                            off_ckpt = off;
-
-                            let mut i = 0;
-                            while i < block_size {
-                                self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
-                                self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
-                                self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
-                                self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
-                                i += L;
-                            }
-
-                            if TRACE {
-                                self.allocated.trace.save_ckpt();
-                            }
-
-                            grow_no_max = false;
-                        }
-
-                        best_max = off_max;
-
-                        y_drop_iter = 0;
-                    }
-
-                    if X_DROP {
-                        if off_max < best_max - state.x_drop {
-                            if x_drop_iter < X_DROP_ITER - 1 {
-                                x_drop_iter += 1;
-                            } else {
-                                // x drop termination
-                                break;
-                            }
-                        } else {
-                            x_drop_iter = 0;
-                        }
-                    }
-
-                    if state.i + block_size > state.query.len() && state.j + block_size > state.reference.len() {
-                        // reached the end of the strings
-                        break;
-                    }
-
-                    // first check if the shift direction is "forced" to avoid going out of bounds
-                    if state.j + block_size > state.reference.len() {
-                        state.i += step;
-                        dir = Direction::Down;
-                        continue;
-                    }
-                    if state.i + block_size > state.query.len() {
-                        state.j += step;
-                        dir = Direction::Right;
-                        continue;
-                    }
-
-                    // check if it is possible to grow
-                    let next_size = if GROW_EXP { block_size * 2 } else { block_size + GROW_STEP };
-                    if next_size <= state.max_size {
-                        // if approximately (block_size / step) iterations has passed since the last best
-                        // max, then it is time to grow
-                        if y_drop_iter > (block_size / step) - 1 || grow_no_max {
-                            // y drop grow block
-                            prev_size = block_size;
-                            block_size = next_size;
-                            dir = Direction::Grow;
-                            if STEP != LARGE_STEP && block_size >= (LARGE_STEP / STEP) * state.min_size {
-                                step = LARGE_STEP;
-                            }
-
-                            // return to checkpoint
-                            state.i = i_ckpt;
-                            state.j = j_ckpt;
-                            off = off_ckpt;
-
-                            let mut i = 0;
-                            while i < prev_size {
-                                self.allocated.D_col.set_vec(&self.allocated.D_col_ckpt, i);
-                                self.allocated.C_col.set_vec(&self.allocated.C_col_ckpt, i);
-                                self.allocated.D_row.set_vec(&self.allocated.D_row_ckpt, i);
-                                self.allocated.R_row.set_vec(&self.allocated.R_row_ckpt, i);
-                                i += L;
-                            }
-
-                            if TRACE {
-                                self.allocated.trace.restore_ckpt();
-                            }
-
-                            y_drop_iter = 0;
-                            continue;
-                        }
-                    }
-
-                    // check if it is possible to shrink
-                    if SHRINK && block_size > state.min_size && y_drop_iter == 0 {
-                        let shrink_max = cmp::max(
-                            Self::suffix_max(self.allocated.D_row.as_ptr(), block_size, step),
-                            Self::suffix_max(self.allocated.D_col.as_ptr(), block_size, step)
-                        );
-                        if shrink_max >= max {
-                            // just to make sure it is not right or down shift so D_corner is not used
-                            prev_dir = Direction::Grow;
-
-                            block_size /= 2;
-                            let mut i = 0;
-                            while i < block_size {
-                                self.allocated.D_col.copy_vec(i, i + block_size);
-                                self.allocated.C_col.copy_vec(i, i + block_size);
-                                self.allocated.D_row.copy_vec(i, i + block_size);
-                                self.allocated.R_row.copy_vec(i, i + block_size);
-                                i += L;
-                            }
-
-                            state.i += block_size;
-                            state.j += block_size;
-
-                            i_ckpt = state.i;
-                            j_ckpt = state.j;
-                            off_ckpt = off;
-
-                            let mut i = 0;
-                            while i < block_size {
-                                self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
-                                self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
-                                self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
-                                self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
-                                i += L;
-                            }
-
-                            right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
-                            down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
-
-                            if TRACE {
-                                self.allocated.trace.save_ckpt();
-                            }
-
-                            y_drop_iter = 0;
-                        }
-                    }
-
-                    // move according to where the max is
-                    if down_max > right_max {
-                        state.i += step;
-                        dir = Direction::Down;
-                    } else {
-                        state.j += step;
-                        dir = Direction::Right;
-                    }
-                }
-
-                #[cfg(any(feature = "debug", feature = "debug_size"))]
-                {
-                    println!("query size: {}, reference size: {}", state.query.len(), state.reference.len());
-                    println!("end block size: {}", block_size);
-                }
-
-                self.res = if X_DROP {
-                    AlignResult {
-                        score: best_max,
-                        query_idx: best_argmax_i,
-                        reference_idx: best_argmax_j
-                    }
-                } else {
-                    debug_assert!(state.i <= state.query.len());
-                    let score = off + match dir {
-                        Direction::Right | Direction::Grow => {
-                            let idx = state.query.len() - state.i;
-                            debug_assert!(idx < block_size);
-                            (self.allocated.D_col.get(idx) as i32) - (ZERO as i32)
-                        },
-                        Direction::Down => {
-                            let idx = state.reference.len() - state.j;
-                            debug_assert!(idx < block_size);
-                            (self.allocated.D_row.get(idx) as i32) - (ZERO as i32)
-                        }
-                    };
-                    AlignResult {
-                        score,
-                        query_idx: state.query.len(),
-                        reference_idx: state.reference.len()
-                    }
-                };
-            }
-        };
-    }
-
     align_core_gen!(align_core, Matrix, State, Self::place_block, Self::place_block);
-    align_core_gen!(align_core, Profile, ProfileState, Self::place_block_profile_right, Self::place_block_profile_down);
+    align_core_gen!(align_profile_core, Profile, StateProfile, Self::place_block_profile_right, Self::place_block_profile_down);
 
     #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
     #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
@@ -835,7 +994,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                 // at this point, C11 is fully calculated and D11 is partially calculated
 
                 let D11_open = simd_adds_i16(D11, simd_subs_i16(gap_open, gap_extend));
-                R11 = simd_prefix_scan_i16(D11_open, prefix_scan_consts);
+                R11 = simd_prefix_scan_i16(D11_open, gap_extend, prefix_scan_consts);
                 // do prefix scan before using R01 to break up dependency chain that depends on
                 // the last element of R01 from the previous loop iteration
                 R11 = simd_max_i16(R11, simd_adds_i16(simd_broadcasthi_i16(R01), gap_extend_all));
@@ -908,167 +1067,8 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
         (D_max, D_argmax)
     }
 
-    /// Place block right or down for sequence-profile alignment.
-    ///
-    /// Assumes all inputs are already relative to the current offset.
-    ///
-    /// Inside this function, everything will be treated as shifting right,
-    /// conceptually. The same process can be trivially used for shifting
-    /// down by calling this function with different parameters.
-    ///
-    /// Right and down shifts must be handled separately since a sequence
-    /// is aligned to a profile.
-    macro_rules! place_block_profile_gen {
-        ($fn_name:ident, $query_type: ty, $reference_type: ty, $right: expr) => {
-            #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
-            #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
-            #[allow(non_snake_case)]
-            unsafe fn $fn_name<P: Profile>(state: &StateProfile<P>,
-                                           query: $query_type,
-                                           reference: $reference_type,
-                                           trace: &mut Trace,
-                                           start_i: usize,
-                                           start_j: usize,
-                                           width: usize,
-                                           height: usize,
-                                           D_col: *mut i16,
-                                           C_col: *mut i16,
-                                           D_row: *mut i16,
-                                           R_row: *mut i16,
-                                           mut D_corner: Simd,
-                                           _right: bool) -> (Simd, Simd) {
-                let gap_extend = simd_set1_i16(reference.get_gap_extend() as i16);
-                let (gap_extend_all, prefix_scan_consts) = get_prefix_scan_consts(gap_extend);
-                let mut D_max = simd_set1_i16(MIN);
-                let mut D_argmax = simd_set1_i16(0);
-                let mut curr_i = simd_set1_i16(0);
-
-                let mut idx = 0;
-                let mut gap_open_C = simd_set1_i16(MIN);
-                let mut gap_close_C = simd_set1_i16(MIN);
-                let mut gap_open_R = simd_set1_i16(MIN);
-                let mut gap_close_R = simd_set1_i16(MIN);
-
-                if width == 0 || height == 0 {
-                    return (D_max, D_argmax);
-                }
-
-                // hottest loop in the whole program
-                for j in 0..width {
-                    let mut R01 = simd_set1_i16(MIN);
-                    let mut D11 = simd_set1_i16(MIN);
-                    let mut R11 = simd_set1_i16(MIN);
-
-                    if $right {
-                        idx = start_j + j;
-                        gap_open_C = reference.get_gap_open_right_C(idx);
-                        gap_close_C = reference.get_gap_close_right_C(idx);
-                        gap_open_R = reference.get_gap_open_right_R(idx);
-                    }
-
-                    let mut i = 0;
-                    while i < height {
-                        let D10 = simd_load(D_col.add(i) as _);
-                        let C10 = simd_load(C_col.add(i) as _);
-                        let D00 = simd_sl_i16!(D10, D_corner, 1);
-                        D_corner = D10;
-
-                        if !$right {
-                            idx = start_i + i;
-                            gap_open_C = query.get_gap_open_down_R(idx);
-                            gap_open_R = query.get_gap_open_down_C(idx);
-                            gap_close_R = query.get_gap_close_down_C(idx);
-                        }
-
-                        let scores = if $right {
-                            reference.get_scores_pos(idx, halfsimd_loadu(query.as_ptr(start_i + i) as _), true)
-                        } else {
-                            query.get_scores_aa(idx, reference.get(start_j + j), false)
-                        };
-                        D11 = simd_adds_i16(D00, scores);
-                        if start_i + i == 0 && start_j + j == 0 {
-                            D11 = simd_insert_i16!(D11, ZERO, 0);
-                        }
-
-                        let C11 = simd_max_i16(simd_adds_i16(C10, gap_extend), simd_adds_i16(D10, simd_adds_i16(gap_open_C, gap_extend)));
-                        D11 = simd_max_i16(D11, if $right { simd_adds_i16(C11, gap_close_C) } else { C11 });
-                        // at this point, C11 is fully calculated and D11 is partially calculated
-
-                        let D11_open = simd_adds_i16(D11, gap_open_R);
-                        R11 = simd_prefix_scan_i16(D11_open, gap_extend, prefix_scan_consts);
-                        // do prefix scan before using R01 to break up dependency chain that depends on
-                        // the last element of R01 from the previous loop iteration
-                        R11 = simd_max_i16(R11, simd_adds_i16(simd_broadcasthi_i16(R01), gap_extend_all));
-                        // fully calculate D11 using R11
-                        D11 = simd_max_i16(D11, if $right { R11 } else { simd_adds_i16(R11, gap_close_R) });
-                        R01 = R11;
-
-                        #[cfg(feature = "debug")]
-                        {
-                            print!("s:   ");
-                            simd_dbg_i16(scores);
-                            print!("D00: ");
-                            simd_dbg_i16(simd_subs_i16(D00, simd_set1_i16(ZERO)));
-                            print!("C11: ");
-                            simd_dbg_i16(simd_subs_i16(C11, simd_set1_i16(ZERO)));
-                            print!("R11: ");
-                            simd_dbg_i16(simd_subs_i16(R11, simd_set1_i16(ZERO)));
-                            print!("D11: ");
-                            simd_dbg_i16(simd_subs_i16(D11, simd_set1_i16(ZERO)));
-                        }
-
-                        if TRACE {
-                            let trace_D_C = simd_cmpeq_i16(D11, C11);
-                            let trace_D_R = simd_cmpeq_i16(D11, R11);
-                            #[cfg(feature = "debug")]
-                            {
-                                print!("D_C: ");
-                                simd_dbg_i16(trace_D_C);
-                                print!("D_R: ");
-                                simd_dbg_i16(trace_D_R);
-                            }
-                            // compress trace with movemask to save space
-                            let trace_data = simd_movemask_i8(simd_blend_i8(trace_D_C, trace_D_R, simd_set1_i16(0xFF00u16 as i16)));
-                            trace.add_trace(trace_data as TraceType);
-                        }
-
-                        D_max = simd_max_i16(D_max, D11);
-
-                        if X_DROP {
-                            // keep track of the best score and its location
-                            let mask = simd_cmpeq_i16(D_max, D11);
-                            D_argmax = simd_blend_i8(D_argmax, curr_i, mask);
-                            curr_i = simd_adds_i16(curr_i, simd_set1_i16(1));
-                        }
-
-                        simd_store(D_col.add(i) as _, D11);
-                        simd_store(C_col.add(i) as _, C11);
-                        i += L;
-                    }
-
-                    D_corner = simd_set1_i16(MIN);
-
-                    ptr::write(D_row.add(j), simd_extract_i16!(D11, L - 1));
-                    ptr::write(R_row.add(j), simd_extract_i16!(R11, L - 1));
-
-                    if !X_DROP && start_i + height > query.len()
-                        && start_j + j >= reference.len() {
-                        if TRACE {
-                            // make sure that the trace index is updated since the rest of the loop
-                            // iterations are skipped
-                            trace.add_trace_idx((width - 1 - j) * (height / L));
-                        }
-                        break;
-                    }
-                }
-
-                (D_max, D_argmax)
-            }
-        };
-    }
-
-    place_block_profile_gen!(place_block_profile_right, &PaddedBytes, &Profile, true);
-    place_block_profile_gen!(place_block_profile_down, &Profile, &PaddedBytes, false);
+    place_block_profile_gen!(place_block_profile_right, query, &PaddedBytes, reference, &P, true);
+    place_block_profile_gen!(place_block_profile_down, reference, &P, query, &PaddedBytes, false);
 
     /// Get the resulting score and ending location of the alignment.
     #[inline]

--- a/src/scan_block.rs
+++ b/src/scan_block.rs
@@ -1826,5 +1826,15 @@ mod tests {
         assert_eq!(res, AlignResult { score: 6, query_idx: 24, reference_idx: 21 });
         a.trace().cigar(res.query_idx, res.reference_idx, &mut cigar);
         assert_eq!(cigar.to_string(), "2M6I16M3D");
+
+        let mut r = AAProfile::from_bytes(b"TTAAAAAAATTTTTTTTTTTT", 16, 1, -1, -2, -1, -1, -1);
+        r.set_gap_close_C(17, -1);
+        r.set_gap_close_C(19, 0);
+        let q = PaddedBytes::from_bytes::<AAMatrix>(b"TTTTTTTTAAAAAAATTTTTTTTT", 16);
+        a.align_profile(&q, &r, 16..=16, 0);
+        let res = a.res();
+        assert_eq!(res, AlignResult { score: 6, query_idx: 24, reference_idx: 21 });
+        a.trace().cigar(res.query_idx, res.reference_idx, &mut cigar);
+        assert_eq!(cigar.to_string(), "2M6I14M3D2M");
     }
 }

--- a/src/scan_block.rs
+++ b/src/scan_block.rs
@@ -184,10 +184,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
     /// computed, even when the the strings are long.
     pub fn align_profile<P: Profile>(&mut self, query: &PaddedBytes, profile: &P, size: RangeInclusive<usize>, x_drop: i32) {
         // check invariants so bad stuff doesn't happen later
-        assert!(gaps.open < 0 && gaps.extend < 0, "Gap costs must be negative!");
-        // there are edge cases with calculating traceback that doesn't work if
-        // gap open does not cost more than gap extend
-        assert!(gaps.open < gaps.extend, "Gap open must cost more than gap extend!");
+        assert!(profile.get_gap_open() < 0, "Gap open cost must be negative!");
         let min_size = if *size.start() < L { L } else { *size.start() };
         let max_size = if *size.end() < L { L } else { *size.end() };
         assert!(min_size < (u16::MAX as usize) && max_size < (u16::MAX as usize), "Block sizes must be smaller than 2^16 - 1!");
@@ -1057,17 +1054,17 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
     // Want this to be inlined in some places and not others, so let
     // compiler decide.
     unsafe fn place_block_profile_down<P: Profile>(state: &StateProfile<P>,
-                                     reference: &Profile,
-                                     query: &PaddedBytes,
+                                     query: &Profile,
+                                     reference: &PaddedBytes,
                                      trace: &mut Trace,
-                                     start_j: usize,
                                      start_i: usize,
-                                     height: usize,
+                                     start_j: usize,
                                      width: usize,
-                                     D_row: *mut i16,
-                                     R_row: *mut i16,
+                                     height: usize,
                                      D_col: *mut i16,
                                      C_col: *mut i16,
+                                     D_row: *mut i16,
+                                     R_row: *mut i16,
                                      mut D_corner: Simd,
                                      _right: bool) -> (Simd, Simd) {
         let gap_open = simd_set1_i16(reference.get_gap_open() as i16);
@@ -1085,7 +1082,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
             let mut D11 = simd_set1_i16(MIN);
             let mut R11 = simd_set1_i16(MIN);
 
-            let idx = start_j + j;
+            let c = reference.get(start_j + j);
 
             let mut i = 0;
             while i < height {
@@ -1094,21 +1091,24 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                 let D00 = simd_sl_i16!(D10, D_corner, 1);
                 D_corner = D10;
 
-                let scores = state.matrix.get_scores_aa(c, halfsimd_loadu(query.as_ptr(start_i + i) as _), false);
+                let idx = start_i + i;
+                let scores = query.get_scores_aa(idx, c, false);
                 D11 = simd_adds_i16(D00, scores);
                 if start_i + i == 0 && start_j + j == 0 {
                     D11 = simd_insert_i16!(D11, ZERO, 0);
                 }
 
-                let C11 = simd_max_i16(simd_adds_i16(C10, gap_extend), simd_adds_i16(D10, gap_open));
+                let gap_extend_C = query.get_gap_extend_down_R(idx);
+                let C11 = simd_max_i16(simd_adds_i16(C10, gap_extend_C), simd_adds_i16(D10, simd_adds_i16(gap_open, gap_extend_C)));
                 D11 = simd_max_i16(D11, C11);
                 // at this point, C11 is fully calculated and D11 is partially calculated
 
-                let D11_open = simd_adds_i16(D11, simd_subs_i16(gap_open, gap_extend));
-                R11 = simd_prefix_scan_i16(D11_open, prefix_scan_consts);
+                let D11_open = simd_adds_i16(D11, gap_open);
+                let gap_extend_R = query.get_gap_extend_down_C(idx);
+                let (R11_temp, gap_extend_all) = simd_prefix_scan_gap_i16(D11_open, gap_extend_R);
                 // do prefix scan before using R01 to break up dependency chain that depends on
                 // the last element of R01 from the previous loop iteration
-                R11 = simd_max_i16(R11, simd_adds_i16(simd_broadcasthi_i16(R01), gap_extend_all));
+                R11 = simd_max_i16(R11_temp, simd_adds_i16(simd_broadcasthi_i16(R01), gap_extend_all));
                 // fully calculate D11 using R11
                 D11 = simd_max_i16(D11, R11);
                 R01 = R11;

--- a/src/scan_block.rs
+++ b/src/scan_block.rs
@@ -53,6 +53,21 @@ struct State<'a, M: Matrix> {
     x_drop: i32
 }
 
+/// Keeps track of internal state and some parameters for block aligner for
+/// sequence to profile alignment.
+///
+/// This does not describe the whole state. The allocated scratch spaces
+/// and other local variables are also needed.
+struct StateProfile<'a, P: Profile> {
+    query: &'a PaddedBytes,
+    i: usize,
+    reference: &'a Profile,
+    j: usize,
+    min_size: usize,
+    max_size: usize,
+    x_drop: i32
+}
+
 /// Data structure storing the settings for block aligner.
 pub struct Block<const TRACE: bool, const X_DROP: bool> {
     res: AlignResult,
@@ -145,475 +160,536 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
         unsafe { self.align_core(s); }
     }
 
-    #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
-    #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
-    #[allow(non_snake_case)]
-    unsafe fn align_core<M: Matrix>(&mut self, mut state: State<M>) {
-        // store the best alignment ending location for x drop alignment
-        let mut best_max = 0i32;
-        let mut best_argmax_i = 0usize;
-        let mut best_argmax_j = 0usize;
+    /// Align a string to a profile with block aligner.
+    ///
+    /// If `TRACE` is true, then information for computing the traceback will be stored.
+    /// After alignment, the traceback CIGAR string can then be computed.
+    /// This will slow down alignment and use a lot more memory.
+    ///
+    /// If `X_DROP` is true, then the alignment process will be terminated early when
+    /// the max score in the current block drops by `x_drop` below the max score encountered
+    /// so far. If `X_DROP` is false, then global alignment is done.
+    ///
+    /// Since larger scores are better, gap and mismatches penalties should be negative.
+    ///
+    /// The minimum and maximum sizes of the block must be powers of 2 that are greater than the
+    /// number of 16-bit lanes in a SIMD vector.
+    ///
+    /// The block aligner algorithm will dynamically shift a block down or right and grow its size
+    /// to efficiently calculate the alignment between two strings.
+    /// This is fast, but it may be slightly less accurate than computing the entire the alignment
+    /// dynamic programming matrix. Growing the size of the block allows larger gaps and
+    /// other potentially difficult regions to be handled correctly.
+    /// 16-bit deltas and 32-bit offsets are used to ensure that accurate scores are
+    /// computed, even when the the strings are long.
+    pub fn align_profile<P: Profile>(&mut self, query: &PaddedBytes, profile: &P, size: RangeInclusive<usize>, x_drop: i32) {
+        // check invariants so bad stuff doesn't happen later
+        assert!(gaps.open < 0 && gaps.extend < 0, "Gap costs must be negative!");
+        // there are edge cases with calculating traceback that doesn't work if
+        // gap open does not cost more than gap extend
+        assert!(gaps.open < gaps.extend, "Gap open must cost more than gap extend!");
+        let min_size = if *size.start() < L { L } else { *size.start() };
+        let max_size = if *size.end() < L { L } else { *size.end() };
+        assert!(min_size < (u16::MAX as usize) && max_size < (u16::MAX as usize), "Block sizes must be smaller than 2^16 - 1!");
+        if GROW_EXP {
+            assert!(min_size.is_power_of_two() && max_size.is_power_of_two(), "Block sizes must be powers of two!");
+        } else {
+            assert!(min_size % L == 0 && max_size % L == 0, "Block sizes must be multiples of {}!", L);
+        }
+        if X_DROP {
+            assert!(x_drop >= 0, "X-drop threshold amount must be nonnegative!");
+        }
 
-        let mut prev_dir = Direction::Grow;
-        let mut dir = Direction::Grow;
-        let mut prev_size = 0;
-        let mut block_size = state.min_size;
-        let mut step = STEP;
+        unsafe { self.allocated.clear(query.len(), profile.len(), max_size, TRACE); }
 
-        // 32-bit score offsets
-        let mut off = 0i32;
-        let mut prev_off;
-        let mut off_max = 0i32;
+        let s = StateProfile {
+            query,
+            i: 0,
+            reference: profile,
+            j: 0,
+            min_size,
+            max_size,
+            x_drop
+        };
+        unsafe { self.align_profile_core(s); }
+    }
 
-        // how many steps since the latest best score was encountered
-        let mut y_drop_iter = 0;
+    macro_rules! align_core_gen {
+        ($fn_name:ident, $matrix_or_profile:ty, $state:ty, $place_block_fn:path) => {
+            #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+            #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+            #[allow(non_snake_case)]
+            unsafe fn $fn_name<M: $matrix_or_profile>(&mut self, mut state: $state<M>) {
+                // store the best alignment ending location for x drop alignment
+                let mut best_max = 0i32;
+                let mut best_argmax_i = 0usize;
+                let mut best_argmax_j = 0usize;
 
-        // how many steps where the X-drop threshold is met
-        let mut x_drop_iter = 0;
+                let mut prev_dir = Direction::Grow;
+                let mut dir = Direction::Grow;
+                let mut prev_size = 0;
+                let mut block_size = state.min_size;
+                let mut step = STEP;
 
-        let mut i_ckpt = state.i;
-        let mut j_ckpt = state.j;
-        let mut off_ckpt = 0i32;
+                // 32-bit score offsets
+                let mut off = 0i32;
+                let mut prev_off;
+                let mut off_max = 0i32;
 
-        let prefix_scan_consts = get_prefix_scan_consts(state.gaps.extend as i16);
-        let gap_extend_all = get_gap_extend_all(state.gaps.extend as i16);
+                // how many steps since the latest best score was encountered
+                let mut y_drop_iter = 0;
 
-        // corner value that affects the score when shifting down then right, or right then down
-        let mut D_corner = simd_set1_i16(MIN);
+                // how many steps where the X-drop threshold is met
+                let mut x_drop_iter = 0;
 
-        loop {
-            #[cfg(feature = "debug")]
-            {
-                println!("i: {}", state.i);
-                println!("j: {}", state.j);
-                println!("{:?}", dir);
-                println!("block size: {}", block_size);
-            }
+                let mut i_ckpt = state.i;
+                let mut j_ckpt = state.j;
+                let mut off_ckpt = 0i32;
 
-            prev_off = off;
-            let mut grow_D_max = simd_set1_i16(MIN);
-            let mut grow_D_argmax = simd_set1_i16(0);
-            let (D_max, D_argmax, mut right_max, mut down_max) = match dir {
-                Direction::Right => {
-                    off = off_max;
+                let prefix_scan_consts = get_prefix_scan_consts(state.gaps.extend as i16);
+                let gap_extend_all = get_gap_extend_all(state.gaps.extend as i16);
+
+                // corner value that affects the score when shifting down then right, or right then down
+                let mut D_corner = simd_set1_i16(MIN);
+
+                loop {
                     #[cfg(feature = "debug")]
-                    println!("off: {}", off);
-                    let off_add = simd_set1_i16(clamp(prev_off - off));
-
-                    if TRACE {
-                        self.allocated.trace.add_block(state.i, state.j + block_size - step, step, block_size, true);
+                    {
+                        println!("i: {}", state.i);
+                        println!("j: {}", state.j);
+                        println!("{:?}", dir);
+                        println!("block size: {}", block_size);
                     }
 
-                    // offset previous columns with newly computed offset
-                    Self::just_offset(block_size, self.allocated.D_col.as_mut_ptr(), self.allocated.C_col.as_mut_ptr(), off_add);
-
-                    // compute new elements in the block as a result of shifting by the step size
-                    // this region should be block_size x step
-                    let (D_max, D_argmax) = Self::place_block(
-                        &state,
-                        state.query,
-                        state.reference,
-                        &mut self.allocated.trace,
-                        state.i,
-                        state.j + block_size - step,
-                        step,
-                        block_size,
-                        self.allocated.D_col.as_mut_ptr(),
-                        self.allocated.C_col.as_mut_ptr(),
-                        self.allocated.temp_buf1.as_mut_ptr(),
-                        self.allocated.temp_buf2.as_mut_ptr(),
-                        if prev_dir == Direction::Down { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
-                        true,
-                        prefix_scan_consts,
-                        gap_extend_all
-                    );
-
-                    // sum of a couple elements on the right border
-                    let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
-
-                    // shift and offset bottom row
-                    D_corner = Self::shift_and_offset(
-                        block_size,
-                        self.allocated.D_row.as_mut_ptr(),
-                        self.allocated.R_row.as_mut_ptr(),
-                        self.allocated.temp_buf1.as_mut_ptr(),
-                        self.allocated.temp_buf2.as_mut_ptr(),
-                        off_add,
-                        step
-                    );
-                    // sum of a couple elements on the bottom border
-                    let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
-
-                    (D_max, D_argmax, right_max, down_max)
-                },
-                Direction::Down => {
-                    off = off_max;
-                    #[cfg(feature = "debug")]
-                    println!("off: {}", off);
-                    let off_add = simd_set1_i16(clamp(prev_off - off));
-
-                    if TRACE {
-                        self.allocated.trace.add_block(state.i + block_size - step, state.j, block_size, step, false);
-                    }
-
-                    // offset previous rows with newly computed offset
-                    Self::just_offset(block_size, self.allocated.D_row.as_mut_ptr(), self.allocated.R_row.as_mut_ptr(), off_add);
-
-                    // compute new elements in the block as a result of shifting by the step size
-                    // this region should be step x block_size
-                    let (D_max, D_argmax) = Self::place_block(
-                        &state,
-                        state.reference,
-                        state.query,
-                        &mut self.allocated.trace,
-                        state.j,
-                        state.i + block_size - step,
-                        step,
-                        block_size,
-                        self.allocated.D_row.as_mut_ptr(),
-                        self.allocated.R_row.as_mut_ptr(),
-                        self.allocated.temp_buf1.as_mut_ptr(),
-                        self.allocated.temp_buf2.as_mut_ptr(),
-                        if prev_dir == Direction::Right { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
-                        false,
-                        prefix_scan_consts,
-                        gap_extend_all
-                    );
-
-                    // sum of a couple elements on the bottom border
-                    let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
-
-                    // shift and offset last column
-                    D_corner = Self::shift_and_offset(
-                        block_size,
-                        self.allocated.D_col.as_mut_ptr(),
-                        self.allocated.C_col.as_mut_ptr(),
-                        self.allocated.temp_buf1.as_mut_ptr(),
-                        self.allocated.temp_buf2.as_mut_ptr(),
-                        off_add,
-                        step
-                    );
-                    // sum of a couple elements on the right border
-                    let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
-
-                    (D_max, D_argmax, right_max, down_max)
-                },
-                Direction::Grow => {
-                    D_corner = simd_set1_i16(MIN);
-                    let grow_step = block_size - prev_size;
-
-                    #[cfg(feature = "debug")]
-                    println!("off: {}", off);
-                    #[cfg(feature = "debug")]
-                    println!("Grow down");
-
-                    if TRACE {
-                        self.allocated.trace.add_block(state.i + prev_size, state.j, prev_size, grow_step, false);
-                    }
-
-                    // down
-                    // this region should be prev_size x prev_size
-                    let (D_max1, D_argmax1) = Self::place_block(
-                        &state,
-                        state.reference,
-                        state.query,
-                        &mut self.allocated.trace,
-                        state.j,
-                        state.i + prev_size,
-                        grow_step,
-                        prev_size,
-                        self.allocated.D_row.as_mut_ptr(),
-                        self.allocated.R_row.as_mut_ptr(),
-                        self.allocated.D_col.as_mut_ptr().add(prev_size),
-                        self.allocated.C_col.as_mut_ptr().add(prev_size),
-                        simd_set1_i16(MIN),
-                        false,
-                        prefix_scan_consts,
-                        gap_extend_all
-                    );
-
-                    #[cfg(feature = "debug")]
-                    println!("Grow right");
-
-                    if TRACE {
-                        self.allocated.trace.add_block(state.i, state.j + prev_size, grow_step, block_size, true);
-                    }
-
-                    // right
-                    // this region should be block_size x prev_size
-                    let (D_max2, D_argmax2) = Self::place_block(
-                        &state,
-                        state.query,
-                        state.reference,
-                        &mut self.allocated.trace,
-                        state.i,
-                        state.j + prev_size,
-                        grow_step,
-                        block_size,
-                        self.allocated.D_col.as_mut_ptr(),
-                        self.allocated.C_col.as_mut_ptr(),
-                        self.allocated.D_row.as_mut_ptr().add(prev_size),
-                        self.allocated.R_row.as_mut_ptr().add(prev_size),
-                        simd_set1_i16(MIN),
-                        true,
-                        prefix_scan_consts,
-                        gap_extend_all
-                    );
-
-                    let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
-                    let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
-                    grow_D_max = D_max1;
-                    grow_D_argmax = D_argmax1;
-
-                    // must update the checkpoint saved values just in case
-                    // the block must grow again from this position
-                    let mut i = 0;
-                    while i < block_size {
-                        self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
-                        self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
-                        self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
-                        self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
-                        i += L;
-                    }
-
-                    if TRACE {
-                        self.allocated.trace.save_ckpt();
-                    }
-
-                    (D_max2, D_argmax2, right_max, down_max)
-                }
-            };
-
-            prev_dir = dir;
-            let D_max_max = simd_hmax_i16(D_max);
-            // grow max is an auxiliary value used when growing because it requires two separate
-            // place_block steps
-            let grow_max = simd_hmax_i16(grow_D_max);
-            // max score of the entire block
-            let max = cmp::max(D_max_max, grow_max);
-            off_max = off + (max as i32) - (ZERO as i32);
-            #[cfg(feature = "debug")]
-            println!("down max: {}, right max: {}", down_max, right_max);
-
-            y_drop_iter += 1;
-            // if block grows but the best score does not improve, then the block must grow again
-            let mut grow_no_max = dir == Direction::Grow;
-
-            if off_max > best_max {
-                if X_DROP {
-                    // TODO: move outside loop
-                    // calculate location with the best score
-                    let lane_idx = simd_hargmax_i16(D_max, D_max_max);
-                    let idx = simd_slow_extract_i16(D_argmax, lane_idx) as usize;
-                    let r = (idx % (block_size / L)) * L + lane_idx;
-                    let c = (block_size - step) + idx / (block_size / L);
-
-                    match dir {
+                    prev_off = off;
+                    let mut grow_D_max = simd_set1_i16(MIN);
+                    let mut grow_D_argmax = simd_set1_i16(0);
+                    let (D_max, D_argmax, mut right_max, mut down_max) = match dir {
                         Direction::Right => {
-                            best_argmax_i = state.i + r;
-                            best_argmax_j = state.j + c;
+                            off = off_max;
+                            #[cfg(feature = "debug")]
+                            println!("off: {}", off);
+                            let off_add = simd_set1_i16(clamp(prev_off - off));
+
+                            if TRACE {
+                                self.allocated.trace.add_block(state.i, state.j + block_size - step, step, block_size, true);
+                            }
+
+                            // offset previous columns with newly computed offset
+                            Self::just_offset(block_size, self.allocated.D_col.as_mut_ptr(), self.allocated.C_col.as_mut_ptr(), off_add);
+
+                            // compute new elements in the block as a result of shifting by the step size
+                            // this region should be block_size x step
+                            let (D_max, D_argmax) = $place_block_fn(
+                                &state,
+                                state.query,
+                                state.reference,
+                                &mut self.allocated.trace,
+                                state.i,
+                                state.j + block_size - step,
+                                step,
+                                block_size,
+                                self.allocated.D_col.as_mut_ptr(),
+                                self.allocated.C_col.as_mut_ptr(),
+                                self.allocated.temp_buf1.as_mut_ptr(),
+                                self.allocated.temp_buf2.as_mut_ptr(),
+                                if prev_dir == Direction::Down { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
+                                true,
+                                prefix_scan_consts,
+                                gap_extend_all
+                            );
+
+                            // sum of a couple elements on the right border
+                            let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
+
+                            // shift and offset bottom row
+                            D_corner = Self::shift_and_offset(
+                                block_size,
+                                self.allocated.D_row.as_mut_ptr(),
+                                self.allocated.R_row.as_mut_ptr(),
+                                self.allocated.temp_buf1.as_mut_ptr(),
+                                self.allocated.temp_buf2.as_mut_ptr(),
+                                off_add,
+                                step
+                            );
+                            // sum of a couple elements on the bottom border
+                            let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
+
+                            (D_max, D_argmax, right_max, down_max)
                         },
                         Direction::Down => {
-                            best_argmax_i = state.i + c;
-                            best_argmax_j = state.j + r;
+                            off = off_max;
+                            #[cfg(feature = "debug")]
+                            println!("off: {}", off);
+                            let off_add = simd_set1_i16(clamp(prev_off - off));
+
+                            if TRACE {
+                                self.allocated.trace.add_block(state.i + block_size - step, state.j, block_size, step, false);
+                            }
+
+                            // offset previous rows with newly computed offset
+                            Self::just_offset(block_size, self.allocated.D_row.as_mut_ptr(), self.allocated.R_row.as_mut_ptr(), off_add);
+
+                            // compute new elements in the block as a result of shifting by the step size
+                            // this region should be step x block_size
+                            let (D_max, D_argmax) = $place_block_fn(
+                                &state,
+                                state.reference,
+                                state.query,
+                                &mut self.allocated.trace,
+                                state.j,
+                                state.i + block_size - step,
+                                step,
+                                block_size,
+                                self.allocated.D_row.as_mut_ptr(),
+                                self.allocated.R_row.as_mut_ptr(),
+                                self.allocated.temp_buf1.as_mut_ptr(),
+                                self.allocated.temp_buf2.as_mut_ptr(),
+                                if prev_dir == Direction::Right { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
+                                false,
+                                prefix_scan_consts,
+                                gap_extend_all
+                            );
+
+                            // sum of a couple elements on the bottom border
+                            let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
+
+                            // shift and offset last column
+                            D_corner = Self::shift_and_offset(
+                                block_size,
+                                self.allocated.D_col.as_mut_ptr(),
+                                self.allocated.C_col.as_mut_ptr(),
+                                self.allocated.temp_buf1.as_mut_ptr(),
+                                self.allocated.temp_buf2.as_mut_ptr(),
+                                off_add,
+                                step
+                            );
+                            // sum of a couple elements on the right border
+                            let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
+
+                            (D_max, D_argmax, right_max, down_max)
                         },
                         Direction::Grow => {
-                            // max could be in either block
-                            if max >= grow_max {
-                                best_argmax_i = state.i + (idx % (block_size / L)) * L + lane_idx;
-                                best_argmax_j = state.j + prev_size + idx / (block_size / L);
-                            } else {
-                                let lane_idx = simd_hargmax_i16(grow_D_max, grow_max);
-                                let idx = simd_slow_extract_i16(grow_D_argmax, lane_idx) as usize;
-                                best_argmax_i = state.i + prev_size + idx / (prev_size / L);
-                                best_argmax_j = state.j + (idx % (prev_size / L)) * L + lane_idx;
+                            D_corner = simd_set1_i16(MIN);
+                            let grow_step = block_size - prev_size;
+
+                            #[cfg(feature = "debug")]
+                            println!("off: {}", off);
+                            #[cfg(feature = "debug")]
+                            println!("Grow down");
+
+                            if TRACE {
+                                self.allocated.trace.add_block(state.i + prev_size, state.j, prev_size, grow_step, false);
+                            }
+
+                            // down
+                            // this region should be prev_size x prev_size
+                            let (D_max1, D_argmax1) = $place_block_fn(
+                                &state,
+                                state.reference,
+                                state.query,
+                                &mut self.allocated.trace,
+                                state.j,
+                                state.i + prev_size,
+                                grow_step,
+                                prev_size,
+                                self.allocated.D_row.as_mut_ptr(),
+                                self.allocated.R_row.as_mut_ptr(),
+                                self.allocated.D_col.as_mut_ptr().add(prev_size),
+                                self.allocated.C_col.as_mut_ptr().add(prev_size),
+                                simd_set1_i16(MIN),
+                                false,
+                                prefix_scan_consts,
+                                gap_extend_all
+                            );
+
+                            #[cfg(feature = "debug")]
+                            println!("Grow right");
+
+                            if TRACE {
+                                self.allocated.trace.add_block(state.i, state.j + prev_size, grow_step, block_size, true);
+                            }
+
+                            // right
+                            // this region should be block_size x prev_size
+                            let (D_max2, D_argmax2) = $place_block_fn(
+                                &state,
+                                state.query,
+                                state.reference,
+                                &mut self.allocated.trace,
+                                state.i,
+                                state.j + prev_size,
+                                grow_step,
+                                block_size,
+                                self.allocated.D_col.as_mut_ptr(),
+                                self.allocated.C_col.as_mut_ptr(),
+                                self.allocated.D_row.as_mut_ptr().add(prev_size),
+                                self.allocated.R_row.as_mut_ptr().add(prev_size),
+                                simd_set1_i16(MIN),
+                                true,
+                                prefix_scan_consts,
+                                gap_extend_all
+                            );
+
+                            let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
+                            let down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
+                            grow_D_max = D_max1;
+                            grow_D_argmax = D_argmax1;
+
+                            // must update the checkpoint saved values just in case
+                            // the block must grow again from this position
+                            let mut i = 0;
+                            while i < block_size {
+                                self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
+                                self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
+                                self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
+                                self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
+                                i += L;
+                            }
+
+                            if TRACE {
+                                self.allocated.trace.save_ckpt();
+                            }
+
+                            (D_max2, D_argmax2, right_max, down_max)
+                        }
+                    };
+
+                    prev_dir = dir;
+                    let D_max_max = simd_hmax_i16(D_max);
+                    // grow max is an auxiliary value used when growing because it requires two separate
+                    // place_block steps
+                    let grow_max = simd_hmax_i16(grow_D_max);
+                    // max score of the entire block
+                    let max = cmp::max(D_max_max, grow_max);
+                    off_max = off + (max as i32) - (ZERO as i32);
+                    #[cfg(feature = "debug")]
+                    println!("down max: {}, right max: {}", down_max, right_max);
+
+                    y_drop_iter += 1;
+                    // if block grows but the best score does not improve, then the block must grow again
+                    let mut grow_no_max = dir == Direction::Grow;
+
+                    if off_max > best_max {
+                        if X_DROP {
+                            // TODO: move outside loop
+                            // calculate location with the best score
+                            let lane_idx = simd_hargmax_i16(D_max, D_max_max);
+                            let idx = simd_slow_extract_i16(D_argmax, lane_idx) as usize;
+                            let r = (idx % (block_size / L)) * L + lane_idx;
+                            let c = (block_size - step) + idx / (block_size / L);
+
+                            match dir {
+                                Direction::Right => {
+                                    best_argmax_i = state.i + r;
+                                    best_argmax_j = state.j + c;
+                                },
+                                Direction::Down => {
+                                    best_argmax_i = state.i + c;
+                                    best_argmax_j = state.j + r;
+                                },
+                                Direction::Grow => {
+                                    // max could be in either block
+                                    if max >= grow_max {
+                                        best_argmax_i = state.i + (idx % (block_size / L)) * L + lane_idx;
+                                        best_argmax_j = state.j + prev_size + idx / (block_size / L);
+                                    } else {
+                                        let lane_idx = simd_hargmax_i16(grow_D_max, grow_max);
+                                        let idx = simd_slow_extract_i16(grow_D_argmax, lane_idx) as usize;
+                                        best_argmax_i = state.i + prev_size + idx / (prev_size / L);
+                                        best_argmax_j = state.j + (idx % (prev_size / L)) * L + lane_idx;
+                                    }
+                                }
                             }
                         }
+
+                        if block_size < state.max_size {
+                            // if able to grow in the future, then save the current location
+                            // as a checkpoint
+                            i_ckpt = state.i;
+                            j_ckpt = state.j;
+                            off_ckpt = off;
+
+                            let mut i = 0;
+                            while i < block_size {
+                                self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
+                                self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
+                                self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
+                                self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
+                                i += L;
+                            }
+
+                            if TRACE {
+                                self.allocated.trace.save_ckpt();
+                            }
+
+                            grow_no_max = false;
+                        }
+
+                        best_max = off_max;
+
+                        y_drop_iter = 0;
                     }
-                }
 
-                if block_size < state.max_size {
-                    // if able to grow in the future, then save the current location
-                    // as a checkpoint
-                    i_ckpt = state.i;
-                    j_ckpt = state.j;
-                    off_ckpt = off;
-
-                    let mut i = 0;
-                    while i < block_size {
-                        self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
-                        self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
-                        self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
-                        self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
-                        i += L;
+                    if X_DROP {
+                        if off_max < best_max - state.x_drop {
+                            if x_drop_iter < X_DROP_ITER - 1 {
+                                x_drop_iter += 1;
+                            } else {
+                                // x drop termination
+                                break;
+                            }
+                        } else {
+                            x_drop_iter = 0;
+                        }
                     }
 
-                    if TRACE {
-                        self.allocated.trace.save_ckpt();
-                    }
-
-                    grow_no_max = false;
-                }
-
-                best_max = off_max;
-
-                y_drop_iter = 0;
-            }
-
-            if X_DROP {
-                if off_max < best_max - state.x_drop {
-                    if x_drop_iter < X_DROP_ITER - 1 {
-                        x_drop_iter += 1;
-                    } else {
-                        // x drop termination
+                    if state.i + block_size > state.query.len() && state.j + block_size > state.reference.len() {
+                        // reached the end of the strings
                         break;
                     }
+
+                    // first check if the shift direction is "forced" to avoid going out of bounds
+                    if state.j + block_size > state.reference.len() {
+                        state.i += step;
+                        dir = Direction::Down;
+                        continue;
+                    }
+                    if state.i + block_size > state.query.len() {
+                        state.j += step;
+                        dir = Direction::Right;
+                        continue;
+                    }
+
+                    // check if it is possible to grow
+                    let next_size = if GROW_EXP { block_size * 2 } else { block_size + GROW_STEP };
+                    if next_size <= state.max_size {
+                        // if approximately (block_size / step) iterations has passed since the last best
+                        // max, then it is time to grow
+                        if y_drop_iter > (block_size / step) - 1 || grow_no_max {
+                            // y drop grow block
+                            prev_size = block_size;
+                            block_size = next_size;
+                            dir = Direction::Grow;
+                            if STEP != LARGE_STEP && block_size >= (LARGE_STEP / STEP) * state.min_size {
+                                step = LARGE_STEP;
+                            }
+
+                            // return to checkpoint
+                            state.i = i_ckpt;
+                            state.j = j_ckpt;
+                            off = off_ckpt;
+
+                            let mut i = 0;
+                            while i < prev_size {
+                                self.allocated.D_col.set_vec(&self.allocated.D_col_ckpt, i);
+                                self.allocated.C_col.set_vec(&self.allocated.C_col_ckpt, i);
+                                self.allocated.D_row.set_vec(&self.allocated.D_row_ckpt, i);
+                                self.allocated.R_row.set_vec(&self.allocated.R_row_ckpt, i);
+                                i += L;
+                            }
+
+                            if TRACE {
+                                self.allocated.trace.restore_ckpt();
+                            }
+
+                            y_drop_iter = 0;
+                            continue;
+                        }
+                    }
+
+                    // check if it is possible to shrink
+                    if SHRINK && block_size > state.min_size && y_drop_iter == 0 {
+                        let shrink_max = cmp::max(
+                            Self::suffix_max(self.allocated.D_row.as_ptr(), block_size, step),
+                            Self::suffix_max(self.allocated.D_col.as_ptr(), block_size, step)
+                        );
+                        if shrink_max >= max {
+                            block_size /= 2;
+                            let mut i = 0;
+                            while i < block_size {
+                                self.allocated.D_col.copy_vec(i, i + block_size);
+                                self.allocated.C_col.copy_vec(i, i + block_size);
+                                self.allocated.D_row.copy_vec(i, i + block_size);
+                                self.allocated.R_row.copy_vec(i, i + block_size);
+                                i += L;
+                            }
+
+                            state.i += block_size;
+                            state.j += block_size;
+
+                            i_ckpt = state.i;
+                            j_ckpt = state.j;
+                            off_ckpt = off;
+
+                            let mut i = 0;
+                            while i < block_size {
+                                self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
+                                self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
+                                self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
+                                self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
+                                i += L;
+                            }
+
+                            right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
+                            down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
+
+                            if TRACE {
+                                self.allocated.trace.save_ckpt();
+                            }
+
+                            y_drop_iter = 0;
+                        }
+                    }
+
+                    // move according to where the max is
+                    if down_max > right_max {
+                        state.i += step;
+                        dir = Direction::Down;
+                    } else {
+                        state.j += step;
+                        dir = Direction::Right;
+                    }
+                }
+
+                #[cfg(any(feature = "debug", feature = "debug_size"))]
+                {
+                    println!("query size: {}, reference size: {}", state.query.len(), state.reference.len());
+                    println!("end block size: {}", block_size);
+                }
+
+                self.res = if X_DROP {
+                    AlignResult {
+                        score: best_max,
+                        query_idx: best_argmax_i,
+                        reference_idx: best_argmax_j
+                    }
                 } else {
-                    x_drop_iter = 0;
-                }
-            }
-
-            if state.i + block_size > state.query.len() && state.j + block_size > state.reference.len() {
-                // reached the end of the strings
-                break;
-            }
-
-            // first check if the shift direction is "forced" to avoid going out of bounds
-            if state.j + block_size > state.reference.len() {
-                state.i += step;
-                dir = Direction::Down;
-                continue;
-            }
-            if state.i + block_size > state.query.len() {
-                state.j += step;
-                dir = Direction::Right;
-                continue;
-            }
-
-            // check if it is possible to grow
-            let next_size = if GROW_EXP { block_size * 2 } else { block_size + GROW_STEP };
-            if next_size <= state.max_size {
-                // if approximately (block_size / step) iterations has passed since the last best
-                // max, then it is time to grow
-                if y_drop_iter > (block_size / step) - 1 || grow_no_max {
-                    // y drop grow block
-                    prev_size = block_size;
-                    block_size = next_size;
-                    dir = Direction::Grow;
-                    if STEP != LARGE_STEP && block_size >= (LARGE_STEP / STEP) * state.min_size {
-                        step = LARGE_STEP;
+                    debug_assert!(state.i <= state.query.len());
+                    let score = off + match dir {
+                        Direction::Right | Direction::Grow => {
+                            let idx = state.query.len() - state.i;
+                            debug_assert!(idx < block_size);
+                            (self.allocated.D_col.get(idx) as i32) - (ZERO as i32)
+                        },
+                        Direction::Down => {
+                            let idx = state.reference.len() - state.j;
+                            debug_assert!(idx < block_size);
+                            (self.allocated.D_row.get(idx) as i32) - (ZERO as i32)
+                        }
+                    };
+                    AlignResult {
+                        score,
+                        query_idx: state.query.len(),
+                        reference_idx: state.reference.len()
                     }
-
-                    // return to checkpoint
-                    state.i = i_ckpt;
-                    state.j = j_ckpt;
-                    off = off_ckpt;
-
-                    let mut i = 0;
-                    while i < prev_size {
-                        self.allocated.D_col.set_vec(&self.allocated.D_col_ckpt, i);
-                        self.allocated.C_col.set_vec(&self.allocated.C_col_ckpt, i);
-                        self.allocated.D_row.set_vec(&self.allocated.D_row_ckpt, i);
-                        self.allocated.R_row.set_vec(&self.allocated.R_row_ckpt, i);
-                        i += L;
-                    }
-
-                    if TRACE {
-                        self.allocated.trace.restore_ckpt();
-                    }
-
-                    y_drop_iter = 0;
-                    continue;
-                }
-            }
-
-            // check if it is possible to shrink
-            if SHRINK && block_size > state.min_size && y_drop_iter == 0 {
-                let shrink_max = cmp::max(
-                    Self::suffix_max(self.allocated.D_row.as_ptr(), block_size, step),
-                    Self::suffix_max(self.allocated.D_col.as_ptr(), block_size, step)
-                );
-                if shrink_max >= max {
-                    block_size /= 2;
-                    let mut i = 0;
-                    while i < block_size {
-                        self.allocated.D_col.copy_vec(i, i + block_size);
-                        self.allocated.C_col.copy_vec(i, i + block_size);
-                        self.allocated.D_row.copy_vec(i, i + block_size);
-                        self.allocated.R_row.copy_vec(i, i + block_size);
-                        i += L;
-                    }
-
-                    state.i += block_size;
-                    state.j += block_size;
-
-                    i_ckpt = state.i;
-                    j_ckpt = state.j;
-                    off_ckpt = off;
-
-                    let mut i = 0;
-                    while i < block_size {
-                        self.allocated.D_col_ckpt.set_vec(&self.allocated.D_col, i);
-                        self.allocated.C_col_ckpt.set_vec(&self.allocated.C_col, i);
-                        self.allocated.D_row_ckpt.set_vec(&self.allocated.D_row, i);
-                        self.allocated.R_row_ckpt.set_vec(&self.allocated.R_row, i);
-                        i += L;
-                    }
-
-                    right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
-                    down_max = Self::prefix_max(self.allocated.D_row.as_ptr(), step);
-
-                    if TRACE {
-                        self.allocated.trace.save_ckpt();
-                    }
-
-                    y_drop_iter = 0;
-                }
-            }
-
-            // move according to where the max is
-            if down_max > right_max {
-                state.i += step;
-                dir = Direction::Down;
-            } else {
-                state.j += step;
-                dir = Direction::Right;
-            }
-        }
-
-        #[cfg(any(feature = "debug", feature = "debug_size"))]
-        {
-            println!("query size: {}, reference size: {}", state.query.len(), state.reference.len());
-            println!("end block size: {}", block_size);
-        }
-
-        self.res = if X_DROP {
-            AlignResult {
-                score: best_max,
-                query_idx: best_argmax_i,
-                reference_idx: best_argmax_j
-            }
-        } else {
-            debug_assert!(state.i <= state.query.len());
-            let score = off + match dir {
-                Direction::Right | Direction::Grow => {
-                    let idx = state.query.len() - state.i;
-                    debug_assert!(idx < block_size);
-                    (self.allocated.D_col.get(idx) as i32) - (ZERO as i32)
-                },
-                Direction::Down => {
-                    let idx = state.reference.len() - state.j;
-                    debug_assert!(idx < block_size);
-                    (self.allocated.D_row.get(idx) as i32) - (ZERO as i32)
-                }
-            };
-            AlignResult {
-                score,
-                query_idx: state.query.len(),
-                reference_idx: state.reference.len()
+                };
             }
         };
     }
+
+    align_core_gen!(align_core, Matrix, State, Self::place_block);
+    align_core_gen!(align_core, Profile, ProfileState, Self::place_block_profile);
 
     #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
     #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
@@ -821,6 +897,138 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
 
                 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "mca"))]
                 asm!("# LLVM-MCA-END", options(nomem, nostack, preserves_flags));
+            }
+
+            D_corner = simd_set1_i16(MIN);
+
+            ptr::write(D_row.add(j), simd_extract_i16!(D11, L - 1));
+            ptr::write(R_row.add(j), simd_extract_i16!(R11, L - 1));
+
+            if !X_DROP && start_i + height > query.len()
+                && start_j + j >= reference.len() {
+                if TRACE {
+                    // make sure that the trace index is updated since the rest of the loop
+                    // iterations are skipped
+                    trace.add_trace_idx((width - 1 - j) * (height / L));
+                }
+                break;
+            }
+        }
+
+        (D_max, D_argmax)
+    }
+
+    /// Place block right or down.
+    ///
+    /// Assumes all inputs are already relative to the current offset.
+    ///
+    /// Inside this function, everything will be treated as shifting right,
+    /// conceptually. The same process can be trivially used for shifting
+    /// down by calling this function with different parameters.
+    #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+    #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+    #[allow(non_snake_case)]
+    // Want this to be inlined in some places and not others, so let
+    // compiler decide.
+    unsafe fn place_block_profile<P: Profile>(state: &StateProfile<P>,
+                                     query: &PaddedBytes,
+                                     reference: &Profile,
+                                     trace: &mut Trace,
+                                     start_i: usize,
+                                     start_j: usize,
+                                     width: usize,
+                                     height: usize,
+                                     D_col: *mut i16,
+                                     C_col: *mut i16,
+                                     D_row: *mut i16,
+                                     R_row: *mut i16,
+                                     mut D_corner: Simd,
+                                     right: bool,
+                                     prefix_scan_consts: PrefixScanConsts) -> (Simd, Simd) {
+        let (gap_open, gap_extend) = Self::get_const_simd(state);
+        let mut D_max = simd_set1_i16(MIN);
+        let mut D_argmax = simd_set1_i16(0);
+        let mut curr_i = simd_set1_i16(0);
+
+        if width == 0 || height == 0 {
+            return (D_max, D_argmax);
+        }
+
+        // hottest loop in the whole program
+        for j in 0..width {
+            let mut R01 = simd_set1_i16(MIN);
+            let mut D11 = simd_set1_i16(MIN);
+            let mut R11 = simd_set1_i16(MIN);
+
+            let c = reference.get(start_j + j);
+
+            let mut i = 0;
+            while i < height {
+                let D10 = simd_load(D_col.add(i) as _);
+                let C10 = simd_load(C_col.add(i) as _);
+                let D00 = simd_sl_i16!(D10, D_corner, 1);
+                D_corner = D10;
+
+                let scores = state.matrix.get_scores(c, halfsimd_loadu(query.as_ptr(start_i + i) as _), right);
+                D11 = simd_adds_i16(D00, scores);
+                if start_i + i == 0 && start_j + j == 0 {
+                    D11 = simd_insert_i16!(D11, ZERO, 0);
+                }
+
+                let C11 = simd_max_i16(simd_adds_i16(C10, gap_extend), simd_adds_i16(D10, gap_open));
+                D11 = simd_max_i16(D11, C11);
+                // at this point, C11 is fully calculated and D11 is partially calculated
+
+                let D11_open = simd_adds_i16(D11, simd_subs_i16(gap_open, gap_extend));
+                R11 = simd_prefix_scan_i16(D11_open, prefix_scan_consts);
+                // do prefix scan before using R01 to break up dependency chain that depends on
+                // the last element of R01 from the previous loop iteration
+                R11 = simd_max_i16(R11, simd_adds_i16(simd_broadcasthi_i16(R01), gap_extend_all));
+                // fully calculate D11 using R11
+                D11 = simd_max_i16(D11, R11);
+                R01 = R11;
+
+                #[cfg(feature = "debug")]
+                {
+                    print!("s:   ");
+                    simd_dbg_i16(scores);
+                    print!("D00: ");
+                    simd_dbg_i16(simd_subs_i16(D00, simd_set1_i16(ZERO)));
+                    print!("C11: ");
+                    simd_dbg_i16(simd_subs_i16(C11, simd_set1_i16(ZERO)));
+                    print!("R11: ");
+                    simd_dbg_i16(simd_subs_i16(R11, simd_set1_i16(ZERO)));
+                    print!("D11: ");
+                    simd_dbg_i16(simd_subs_i16(D11, simd_set1_i16(ZERO)));
+                }
+
+                if TRACE {
+                    let trace_D_C = simd_cmpeq_i16(D11, C11);
+                    let trace_D_R = simd_cmpeq_i16(D11, R11);
+                    #[cfg(feature = "debug")]
+                    {
+                        print!("D_C: ");
+                        simd_dbg_i16(trace_D_C);
+                        print!("D_R: ");
+                        simd_dbg_i16(trace_D_R);
+                    }
+                    // compress trace with movemask to save space
+                    let trace_data = simd_movemask_i8(simd_blend_i8(trace_D_C, trace_D_R, simd_set1_i16(0xFF00u16 as i16)));
+                    trace.add_trace(trace_data as TraceType);
+                }
+
+                D_max = simd_max_i16(D_max, D11);
+
+                if X_DROP {
+                    // keep track of the best score and its location
+                    let mask = simd_cmpeq_i16(D_max, D11);
+                    D_argmax = simd_blend_i8(D_argmax, curr_i, mask);
+                    curr_i = simd_adds_i16(curr_i, simd_set1_i16(1));
+                }
+
+                simd_store(D_col.add(i) as _, D11);
+                simd_store(C_col.add(i) as _, C11);
+                i += L;
             }
 
             D_corner = simd_set1_i16(MIN);

--- a/src/scan_block.rs
+++ b/src/scan_block.rs
@@ -215,7 +215,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
     }
 
     macro_rules! align_core_gen {
-        ($fn_name:ident, $matrix_or_profile:ty, $state:ty, $place_block_fn:path) => {
+        ($fn_name:ident, $matrix_or_profile:ty, $state:ty, $place_block_right_fn:path, $place_block_down_fn:path) => {
             #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
             #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
             #[allow(non_snake_case)]
@@ -245,9 +245,6 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                 let mut i_ckpt = state.i;
                 let mut j_ckpt = state.j;
                 let mut off_ckpt = 0i32;
-
-                let prefix_scan_consts = get_prefix_scan_consts(state.gaps.extend as i16);
-                let gap_extend_all = get_gap_extend_all(state.gaps.extend as i16);
 
                 // corner value that affects the score when shifting down then right, or right then down
                 let mut D_corner = simd_set1_i16(MIN);
@@ -280,7 +277,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
 
                             // compute new elements in the block as a result of shifting by the step size
                             // this region should be block_size x step
-                            let (D_max, D_argmax) = $place_block_fn(
+                            let (D_max, D_argmax) = $place_block_right_fn(
                                 &state,
                                 state.query,
                                 state.reference,
@@ -294,9 +291,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                                 self.allocated.temp_buf1.as_mut_ptr(),
                                 self.allocated.temp_buf2.as_mut_ptr(),
                                 if prev_dir == Direction::Down { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
-                                true,
-                                prefix_scan_consts,
-                                gap_extend_all
+                                true
                             );
 
                             // sum of a couple elements on the right border
@@ -332,7 +327,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
 
                             // compute new elements in the block as a result of shifting by the step size
                             // this region should be step x block_size
-                            let (D_max, D_argmax) = $place_block_fn(
+                            let (D_max, D_argmax) = $place_block_down_fn(
                                 &state,
                                 state.reference,
                                 state.query,
@@ -346,9 +341,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                                 self.allocated.temp_buf1.as_mut_ptr(),
                                 self.allocated.temp_buf2.as_mut_ptr(),
                                 if prev_dir == Direction::Right { simd_adds_i16(D_corner, off_add) } else { simd_set1_i16(MIN) },
-                                false,
-                                prefix_scan_consts,
-                                gap_extend_all
+                                false
                             );
 
                             // sum of a couple elements on the bottom border
@@ -384,7 +377,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
 
                             // down
                             // this region should be prev_size x prev_size
-                            let (D_max1, D_argmax1) = $place_block_fn(
+                            let (D_max1, D_argmax1) = $place_block_down_fn(
                                 &state,
                                 state.reference,
                                 state.query,
@@ -398,9 +391,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                                 self.allocated.D_col.as_mut_ptr().add(prev_size),
                                 self.allocated.C_col.as_mut_ptr().add(prev_size),
                                 simd_set1_i16(MIN),
-                                false,
-                                prefix_scan_consts,
-                                gap_extend_all
+                                false
                             );
 
                             #[cfg(feature = "debug")]
@@ -412,7 +403,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
 
                             // right
                             // this region should be block_size x prev_size
-                            let (D_max2, D_argmax2) = $place_block_fn(
+                            let (D_max2, D_argmax2) = $place_block_right_fn(
                                 &state,
                                 state.query,
                                 state.reference,
@@ -426,9 +417,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                                 self.allocated.D_row.as_mut_ptr().add(prev_size),
                                 self.allocated.R_row.as_mut_ptr().add(prev_size),
                                 simd_set1_i16(MIN),
-                                true,
-                                prefix_scan_consts,
-                                gap_extend_all
+                                true
                             );
 
                             let right_max = Self::prefix_max(self.allocated.D_col.as_ptr(), step);
@@ -691,8 +680,8 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
         };
     }
 
-    align_core_gen!(align_core, Matrix, State, Self::place_block);
-    align_core_gen!(align_core, Profile, ProfileState, Self::place_block_profile);
+    align_core_gen!(align_core, Matrix, State, Self::place_block, Self::place_block);
+    align_core_gen!(align_core, Profile, ProfileState, Self::place_block_profile_right, Self::place_block_profile_down);
 
     #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
     #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
@@ -807,10 +796,10 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                                      D_row: *mut i16,
                                      R_row: *mut i16,
                                      mut D_corner: Simd,
-                                     right: bool,
-                                     prefix_scan_consts: PrefixScanConsts,
-                                     gap_extend_all: Simd) -> (Simd, Simd) {
-        let (gap_open, gap_extend) = Self::get_const_simd(state);
+                                     right: bool) -> (Simd, Simd) {
+        let gap_open = simd_set1_i16(state.gaps.open as i16);
+        let gap_extend = simd_set1_i16(state.gaps.extend as i16);
+        let (gap_extend_all, prefix_scan_consts) = get_prefix_scan_consts(gap_extend);
         let mut D_max = simd_set1_i16(MIN);
         let mut D_argmax = simd_set1_i16(0);
         let mut curr_i = simd_set1_i16(0);
@@ -933,7 +922,7 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
     #[allow(non_snake_case)]
     // Want this to be inlined in some places and not others, so let
     // compiler decide.
-    unsafe fn place_block_profile<P: Profile>(state: &StateProfile<P>,
+    unsafe fn place_block_profile_right<P: Profile>(state: &StateProfile<P>,
                                      query: &PaddedBytes,
                                      reference: &Profile,
                                      trace: &mut Trace,
@@ -946,9 +935,8 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                                      D_row: *mut i16,
                                      R_row: *mut i16,
                                      mut D_corner: Simd,
-                                     right: bool,
-                                     prefix_scan_consts: PrefixScanConsts) -> (Simd, Simd) {
-        let (gap_open, gap_extend) = Self::get_const_simd(state);
+                                     _right: bool) -> (Simd, Simd) {
+        let gap_open = simd_set1_i16(reference.get_gap_open() as i16);
         let mut D_max = simd_set1_i16(MIN);
         let mut D_argmax = simd_set1_i16(0);
         let mut curr_i = simd_set1_i16(0);
@@ -963,7 +951,10 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
             let mut D11 = simd_set1_i16(MIN);
             let mut R11 = simd_set1_i16(MIN);
 
-            let c = reference.get(start_j + j);
+            let idx = start_j + j;
+            let gap_extend_C = reference.get_gap_extend_right_C(idx);
+            let gap_extend_R = reference.get_gap_extend_right_R(idx);
+            let (gap_extend_all, prefix_scan_consts) = get_prefix_scan_consts(gap_extend_R);
 
             let mut i = 0;
             while i < height {
@@ -972,7 +963,138 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                 let D00 = simd_sl_i16!(D10, D_corner, 1);
                 D_corner = D10;
 
-                let scores = state.matrix.get_scores(c, halfsimd_loadu(query.as_ptr(start_i + i) as _), right);
+                let scores = reference.get_scores_pos(idx, halfsimd_loadu(query.as_ptr(start_i + i) as _), true);
+                D11 = simd_adds_i16(D00, scores);
+                if start_i + i == 0 && start_j + j == 0 {
+                    D11 = simd_insert_i16!(D11, ZERO, 0);
+                }
+
+                let C11 = simd_max_i16(simd_adds_i16(C10, gap_extend_C), simd_adds_i16(D10, simd_adds_i16(gap_open, gap_extend_C)));
+                D11 = simd_max_i16(D11, C11);
+                // at this point, C11 is fully calculated and D11 is partially calculated
+
+                let D11_open = simd_adds_i16(D11, gap_open);
+                R11 = simd_prefix_scan_i16(D11_open, gap_extend_R, prefix_scan_consts);
+                // do prefix scan before using R01 to break up dependency chain that depends on
+                // the last element of R01 from the previous loop iteration
+                R11 = simd_max_i16(R11, simd_adds_i16(simd_broadcasthi_i16(R01), gap_extend_all));
+                // fully calculate D11 using R11
+                D11 = simd_max_i16(D11, R11);
+                R01 = R11;
+
+                #[cfg(feature = "debug")]
+                {
+                    print!("s:   ");
+                    simd_dbg_i16(scores);
+                    print!("D00: ");
+                    simd_dbg_i16(simd_subs_i16(D00, simd_set1_i16(ZERO)));
+                    print!("C11: ");
+                    simd_dbg_i16(simd_subs_i16(C11, simd_set1_i16(ZERO)));
+                    print!("R11: ");
+                    simd_dbg_i16(simd_subs_i16(R11, simd_set1_i16(ZERO)));
+                    print!("D11: ");
+                    simd_dbg_i16(simd_subs_i16(D11, simd_set1_i16(ZERO)));
+                }
+
+                if TRACE {
+                    let trace_D_C = simd_cmpeq_i16(D11, C11);
+                    let trace_D_R = simd_cmpeq_i16(D11, R11);
+                    #[cfg(feature = "debug")]
+                    {
+                        print!("D_C: ");
+                        simd_dbg_i16(trace_D_C);
+                        print!("D_R: ");
+                        simd_dbg_i16(trace_D_R);
+                    }
+                    // compress trace with movemask to save space
+                    let trace_data = simd_movemask_i8(simd_blend_i8(trace_D_C, trace_D_R, simd_set1_i16(0xFF00u16 as i16)));
+                    trace.add_trace(trace_data as TraceType);
+                }
+
+                D_max = simd_max_i16(D_max, D11);
+
+                if X_DROP {
+                    // keep track of the best score and its location
+                    let mask = simd_cmpeq_i16(D_max, D11);
+                    D_argmax = simd_blend_i8(D_argmax, curr_i, mask);
+                    curr_i = simd_adds_i16(curr_i, simd_set1_i16(1));
+                }
+
+                simd_store(D_col.add(i) as _, D11);
+                simd_store(C_col.add(i) as _, C11);
+                i += L;
+            }
+
+            D_corner = simd_set1_i16(MIN);
+
+            ptr::write(D_row.add(j), simd_extract_i16!(D11, L - 1));
+            ptr::write(R_row.add(j), simd_extract_i16!(R11, L - 1));
+
+            if !X_DROP && start_i + height > query.len()
+                && start_j + j >= reference.len() {
+                if TRACE {
+                    // make sure that the trace index is updated since the rest of the loop
+                    // iterations are skipped
+                    trace.add_trace_idx((width - 1 - j) * (height / L));
+                }
+                break;
+            }
+        }
+
+        (D_max, D_argmax)
+    }
+
+    /// Place block right or down.
+    ///
+    /// Assumes all inputs are already relative to the current offset.
+    ///
+    /// Inside this function, everything will be treated as shifting right,
+    /// conceptually. The same process can be trivially used for shifting
+    /// down by calling this function with different parameters.
+    #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+    #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+    #[allow(non_snake_case)]
+    // Want this to be inlined in some places and not others, so let
+    // compiler decide.
+    unsafe fn place_block_profile_down<P: Profile>(state: &StateProfile<P>,
+                                     reference: &Profile,
+                                     query: &PaddedBytes,
+                                     trace: &mut Trace,
+                                     start_j: usize,
+                                     start_i: usize,
+                                     height: usize,
+                                     width: usize,
+                                     D_row: *mut i16,
+                                     R_row: *mut i16,
+                                     D_col: *mut i16,
+                                     C_col: *mut i16,
+                                     mut D_corner: Simd,
+                                     _right: bool) -> (Simd, Simd) {
+        let gap_open = simd_set1_i16(reference.get_gap_open() as i16);
+        let mut D_max = simd_set1_i16(MIN);
+        let mut D_argmax = simd_set1_i16(0);
+        let mut curr_i = simd_set1_i16(0);
+
+        if width == 0 || height == 0 {
+            return (D_max, D_argmax);
+        }
+
+        // hottest loop in the whole program
+        for j in 0..width {
+            let mut R01 = simd_set1_i16(MIN);
+            let mut D11 = simd_set1_i16(MIN);
+            let mut R11 = simd_set1_i16(MIN);
+
+            let idx = start_j + j;
+
+            let mut i = 0;
+            while i < height {
+                let D10 = simd_load(D_col.add(i) as _);
+                let C10 = simd_load(C_col.add(i) as _);
+                let D00 = simd_sl_i16!(D10, D_corner, 1);
+                D_corner = D10;
+
+                let scores = state.matrix.get_scores_aa(c, halfsimd_loadu(query.as_ptr(start_i + i) as _), false);
                 D11 = simd_adds_i16(D00, scores);
                 if start_i + i == 0 && start_j + j == 0 {
                     D11 = simd_insert_i16!(D11, ZERO, 0);
@@ -1064,16 +1186,6 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
     pub fn trace(&self) -> &Trace {
         assert!(TRACE);
         &self.allocated.trace
-    }
-
-    #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
-    #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
-    #[inline]
-    unsafe fn get_const_simd<M: Matrix>(state: &State<M>) -> (Simd, Simd) {
-        // some useful constant simd vectors
-        let gap_open = simd_set1_i16(state.gaps.open as i16);
-        let gap_extend = simd_set1_i16(state.gaps.extend as i16);
-        (gap_open, gap_extend)
     }
 }
 

--- a/src/scan_block.rs
+++ b/src/scan_block.rs
@@ -605,6 +605,9 @@ impl<const TRACE: bool, const X_DROP: bool> Block<{ TRACE }, { X_DROP }> {
                             Self::suffix_max(self.allocated.D_col.as_ptr(), block_size, step)
                         );
                         if shrink_max >= max {
+                            // just to make sure it is not right or down shift so D_corner is not used
+                            prev_dir = Direction::Grow;
+
                             block_size /= 2;
                             let mut i = 0;
                             while i < block_size {

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -422,14 +422,28 @@ impl Profile for AAProfile {
     #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
     #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
     #[inline]
-    unsafe fn get_gap_extend_C(&self, i: usize) -> Simd {
+    unsafe fn get_gap_extend_right_C(&self, i: usize) -> Simd {
         simd_set1_i16(*self.pos_gap_extend_C.as_ptr().add(i) as i16)
     }
 
     #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
     #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
     #[inline]
-    unsafe fn get_gap_extend_R(&self, i: usize) -> Simd {
+    unsafe fn get_gap_extend_right_R(&self, i: usize) -> Simd {
+        simd_set1_i16(*self.pos_gap_extend_R.as_ptr().add(i) as i16)
+    }
+
+    #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+    #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+    #[inline]
+    unsafe fn get_gap_extend_down_C(&self, i: usize) -> Simd {
+        simd_loadu(self.pos_gap_extend_C.as_ptr().add(i) as *const Simd)
+    }
+
+    #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+    #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+    #[inline]
+    unsafe fn get_gap_extend_down_R(&self, i: usize) -> Simd {
         simd_loadu(self.pos_gap_extend_R.as_ptr().add(i) as *const Simd)
     }
 

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -308,6 +308,9 @@ pub trait Profile {
 
     /// Create a new profile of a specific length, with default (usually nonsense) values.
     fn new(str_len: usize, block_size: usize, gap_extend: i8) -> Self;
+    /// Create a new profile from a byte string.
+    fn from_bytes(b: &[u8], block_size: usize, match_score: i8, mismatch_score: i8, gap_open_C: i8, gap_close_C: i8, gap_open_R: i8, gap_extend: i8) -> Self;
+
     /// Get the length of the profile.
     fn len(&self) -> usize;
     /// Clear the profile so it can be used for profile lengths less than or equal
@@ -385,6 +388,25 @@ impl Profile for AAProfile {
             len,
             str_len
         }
+    }
+
+    #[allow(non_snake_case)]
+    fn from_bytes(b: &[u8], block_size: usize, match_score: i8, mismatch_score: i8, gap_open_C: i8, gap_close_C: i8, gap_open_R: i8, gap_extend: i8) -> Self {
+        let mut res = Self::new(b.len(), block_size, gap_extend);
+
+        for i in 0..b.len() {
+            for c in b'A'..=b'Z' {
+                res.set(i + 1, c, if c == b[i] { match_score } else { mismatch_score });
+            }
+        }
+
+        for i in 0..b.len() + 1 {
+            res.set_gap_open_C(i, gap_open_C);
+            res.set_gap_close_C(i, gap_close_C);
+            res.set_gap_open_R(i, gap_open_R);
+        }
+
+        res
     }
 
     fn len(&self) -> usize {

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -305,11 +305,17 @@ pub trait Profile {
     /// Byte to use as padding.
     const NULL: u8;
     /// Create a new matrix with default (usually nonsense) values.
-    fn new(len: usize) -> Self;
+    fn new(len: usize, gap_open: i8) -> Self;
     /// Set the score for a position and byte.
     fn set(&mut self, i: usize, b: u8, score: i8);
+    /// Set the gap extend cost for a column.
+    fn set_gap_extend_C(&mut self, i: usize, gap: i8);
+    /// Set the gap extend cost for a row.
+    fn set_gap_extend_R(&mut self, i: usize, gap: i8);
     /// Get the score for a position and byte.
     fn get(&self, i: usize, b: u8) -> i8;
+    /// Get the gap open cost.
+    fn get_gap_open(&self) -> i8;
     /// Get the pointer for a specific index.
     fn as_ptr_pos(&self, i: usize) -> *const i8;
     /// Get the pointer for a specific amino acid.
@@ -318,6 +324,10 @@ pub trait Profile {
     unsafe fn get_scores_pos(&self, i: usize, c: u8, right: bool) -> Simd;
     /// Get the scores for a certain byte and a certain SIMD vector of bytes.
     unsafe fn get_scores_aa(&self, i: usize, v: HalfSimd, right: bool) -> Simd;
+    /// Get the gap extend cost for a column.
+    unsafe fn get_gap_extend_C(&self, i: usize) -> Simd;
+    /// Get the gap extend cost for a row.
+    unsafe fn get_gap_extend_R(&self, i: usize) -> Simd;
     /// Convert a byte to a better storage format that makes retrieving scores
     /// easier.
     fn convert_char(c: u8) -> u8;
@@ -329,17 +339,23 @@ pub trait Profile {
 pub struct AAProfile {
     aa_pos: Vec<i16>,
     pos_aa: Vec<i8>,
+    gap_open: i8,
+    pos_gap_extend_C: Vec<i8>,
+    pos_gap_extend_R: Vec<i16>,
     len: usize
 }
 
 impl Profile for AAProfile {
     const NULL: u8 = b'A' + 26u8;
 
-    fn new(len: usize) -> Self {
-        let len = (len + 31) / 32 * 32;
+    fn new(len: usize, block_size: usize, gap_open: i8) -> Self {
+        let len = len + block_size + 1;
         Self {
             aa_pos: vec![i8::MIN as i16; 32 * len],
             pos_aa: vec![i8::MIN; len * 32],
+            gap_open,
+            pos_gap_extend_C: vec![i8::MIN; len * 32],
+            pos_gap_extend_R: vec![i8::MIN as i16; len * 32],
             len
         }
     }
@@ -353,11 +369,23 @@ impl Profile for AAProfile {
         self.aa_pos[idx] = score as i16;
     }
 
+    fn set_gap_extend_C(&mut self, i: usize, gap: i8) {
+        self.pos_gap_extend_C[i] = gap;
+    }
+
+    fn set_gap_extend_R(&mut self, i: usize, gap: i8) {
+        self.pos_gap_extend_R[i] = gap;
+    }
+
     fn get(&self, i: usize, b: u8) -> i8 {
         let b = b.to_ascii_uppercase();
         assert!(b'A' <= b && b <= b'Z' + 1);
         let idx = i * 32 + ((b - b'A') as usize);
         self.pos_aa[idx]
+    }
+
+    fn get_gap_open(&self) -> i8 {
+        self.gap_open
     }
 
     #[inline]
@@ -378,8 +406,8 @@ impl Profile for AAProfile {
     unsafe fn get_scores_pos(&self, i: usize, v: HalfSimd, _right: bool) -> Simd {
         // efficiently lookup scores for each character in v
         let matrix_ptr = self.as_ptr_pos(i);
-        let scores1 = halfsimd_load(matrix_ptr as *const HalfSimd);
-        let scores2 = halfsimd_load((matrix_ptr as *const HalfSimd).add(1));
+        let scores1 = halfsimd_loadu(matrix_ptr as *const HalfSimd);
+        let scores2 = halfsimd_loadu((matrix_ptr as *const HalfSimd).add(1));
         halfsimd_lookup2_i16(scores1, scores2, v)
     }
 
@@ -388,7 +416,21 @@ impl Profile for AAProfile {
     #[inline]
     unsafe fn get_scores_aa(&self, i: usize, c: u8, _right: bool) -> Simd {
         let matrix_ptr = self.as_ptr_aa(c as usize);
-        simd_load(matrix_ptr.add(i) as *const Simd)
+        simd_loadu(matrix_ptr.add(i) as *const Simd)
+    }
+
+    #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+    #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+    #[inline]
+    unsafe fn get_gap_extend_C(&self, i: usize) -> Simd {
+        simd_set1_i16(*self.pos_gap_extend_C.as_ptr().add(i) as i16)
+    }
+
+    #[cfg_attr(feature = "simd_avx2", target_feature(enable = "avx2"))]
+    #[cfg_attr(feature = "simd_wasm", target_feature(enable = "simd128"))]
+    #[inline]
+    unsafe fn get_gap_extend_R(&self, i: usize) -> Simd {
+        simd_loadu(self.pos_gap_extend_R.as_ptr().add(i) as *const Simd)
     }
 
     #[inline]

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -301,6 +301,7 @@ pub struct Gaps {
     pub extend: i8
 }
 
+#[allow(non_snake_case)]
 pub trait Profile {
     /// Byte to use as padding.
     const NULL: u8;
@@ -356,6 +357,7 @@ pub trait Profile {
 
 
 /// Amino acid position specific scoring matrix.
+#[allow(non_snake_case)]
 #[derive(Clone, PartialEq, Debug)]
 pub struct AAProfile {
     aa_pos: Vec<i16>,

--- a/src/scores.rs
+++ b/src/scores.rs
@@ -387,7 +387,7 @@ impl Profile for AAProfile {
     }
 
     fn set_gap_open_C(&mut self, i: usize, gap: i8) {
-        assert!(gap < 0);
+        assert!(gap < 0, "Gap open cost must be negative!");
         self.pos_gap_open_C[i] = gap;
     }
 
@@ -396,7 +396,7 @@ impl Profile for AAProfile {
     }
 
     fn set_gap_open_R(&mut self, i: usize, gap: i8) {
-        assert!(gap < 0);
+        assert!(gap < 0, "Gap open cost must be negative!");
         self.pos_gap_open_R[i] = gap;
     }
 

--- a/src/simd128.rs
+++ b/src/simd128.rs
@@ -454,13 +454,13 @@ mod tests {
 
             let vec = A([8, 9, 10, 15, 12, 13, 14, 11]);
             let gap = simd_set1_i16(0);
-            let consts = get_prefix_scan_consts(gap);
+            let (_, consts) = get_prefix_scan_consts(gap);
             let res = simd_prefix_scan_i16(simd_load(vec.0.as_ptr() as *const Simd), gap, consts);
             simd_assert_vec_eq(res, [8, 9, 10, 15, 15, 15, 15, 15]);
 
             let vec = A([8, 9, 10, 15, 12, 13, 14, 11]);
             let gap = simd_set1_i16(-1);
-            let consts = get_prefix_scan_consts(gap);
+            let (_, consts) = get_prefix_scan_consts(gap);
             let res = simd_prefix_scan_i16(simd_load(vec.0.as_ptr() as *const Simd), gap, consts);
             simd_assert_vec_eq(res, [8, 9, 10, 15, 14, 13, 14, 13]);
         }

--- a/src/simd128.rs
+++ b/src/simd128.rs
@@ -241,7 +241,7 @@ pub unsafe fn simd_hargmax_i16(v: Simd, max: i16) -> usize {
 #[inline]
 #[allow(non_snake_case)]
 #[allow(dead_code)]
-pub unsafe fn simd_naive_prefix_scan_i16(R_max: Simd, gap_cost: SIMD, _gap_cost_lane: PrefixScanConsts) -> Simd {
+pub unsafe fn simd_naive_prefix_scan_i16(R_max: Simd, gap_cost: Simd, _gap_cost_lane: PrefixScanConsts) -> Simd {
     let mut curr = R_max;
 
     for _i in 0..(L - 1) {


### PR DESCRIPTION
The new sequence to profile alignment algorithm allows sequences to be aligned to position specific scoring matrices. These PSSMs support position specific substitution scores, along with gap opening and closing penalties. The gap extend penalty is constant.

Also fixed a bug in reporting the wrong alignment tracebacks in certain cases.

Still need to add C bindings for sequence to profile alignments.