### PR TITLE
Put cbindgen dependency behind a default-enabled feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ debug_size = []
 # Prepare code for analysis by llvm-mca
 mca = []
 
+default = ["cbindgen"]
+
 [profile.release]
 debug-assertions = false
 lto = "thin"
@@ -50,7 +52,7 @@ rand = { version = "^0.8", default-features = false, features = ["std_rng", "all
 bio = "^0.33"
 
 [build-dependencies]
-cbindgen = "^0.20.0"
+cbindgen = { version = "^0.20.0", optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "aarch64")))'.dev-dependencies]
 parasailors = { git = "https://github.com/Daniel-Liu-c0deb0t/parasailors-new" }

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,11 @@
-use cbindgen;
-
-use std::env;
-
 fn main() {
-    if env::var("BLOCK_ALIGNER_C").is_ok() {
-        let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-        cbindgen::generate(&crate_dir)
-            .unwrap()
-            .write_to_file(format!("{}/c/block_aligner.h", crate_dir));
+    #[cfg(feature = "cbindgen")]
+    {
+        if std::env::var("BLOCK_ALIGNER_C").is_ok() {
+            let crate_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+            cbindgen::generate(&crate_dir)
+                .unwrap()
+                .write_to_file(format!("{}/c/block_aligner.h", crate_dir));
+        }
     }
 }


### PR DESCRIPTION
This removes a bunch of unneeded dependencies when c bindings are not needed.