### PR TITLE
Fix: FFI API not available in WASM

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub mod scores;
 #[cfg(any(feature = "simd_sse2", feature = "simd_avx2", feature = "simd_wasm", feature = "simd_neon"))]
 pub mod cigar;
 
-#[cfg(any(feature = "simd_sse2", feature = "simd_avx2", feature = "simd_neon"))]
+#[cfg(any(feature = "simd_sse2", feature = "simd_avx2", feature = "simd_wasm", feature = "simd_neon"))]
 #[doc(hidden)]
 pub mod ffi;
 


### PR DESCRIPTION
Currently none of the FFI API is available in WASM. This small change exposes the FFI API.

How do I sync the change also to the 3di branch? This looks to be quite a bit of work.